### PR TITLE
Fixed TLstFile::Open to set library specific classes

### DIFF
--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -19,7 +19,8 @@
 #include "TLstEvent.h"
 #include "TRunInfo.h"
 #include "TILLDetectorInformation.h"
-#include "GVersion.h"
+#include "TILLMnemonic.h"
+#include "ILLDataVersion.h"
 
 /// \cond CLASSIMP
 ClassImp(TLstFile)
@@ -103,9 +104,12 @@ bool TLstFile::Open(const char* filename)
 #define O_LARGEFILE 0
 #endif
 
+	// setup TChannel to use our mnemonics
+	TChannel::SetMnemonicClass(TILLMnemonic::Class());
+
    TRunInfo::SetRunInfo(GetRunNumber(), GetSubRunNumber());
 	TRunInfo::ClearVersion();
-   TRunInfo::SetVersion(GRSI_RELEASE);
+   TRunInfo::SetVersion(ILLDATA_RELEASE);
 
    std::cout<<"Successfully read "<<fFileSize - headerSize<<" bytes into buffer!"<<std::endl;
 

--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -18,6 +18,7 @@
 #include "TLstFile.h"
 #include "TLstEvent.h"
 #include "TRunInfo.h"
+#include "TILLDetectorInformation.h"
 #include "GVersion.h"
 
 /// \cond CLASSIMP
@@ -107,6 +108,9 @@ bool TLstFile::Open(const char* filename)
    TRunInfo::SetVersion(GRSI_RELEASE);
 
    std::cout<<"Successfully read "<<fFileSize - headerSize<<" bytes into buffer!"<<std::endl;
+
+	TILLDetectorInformation* detInfo = new TILLDetectorInformation();
+	TRunInfo::SetDetectorInformation(detInfo);
 
    return true;
 }


### PR DESCRIPTION
- sets the detector information to the TILLDetectorInformation, and
- sets the mnemonic class to be TILLMnemonic