### PR TITLE
Added (empty) TLstFile::Skip function

### DIFF
--- a/include/TLstFile.h
+++ b/include/TLstFile.h
@@ -43,6 +43,7 @@ public:
 #ifndef __CINT__
    int Read(std::shared_ptr<TRawEvent> lstEvent) override; ///< Read one event from the file
 #endif
+	void Skip(size_t nofEvents) override; ///< Skip nofEvents from the file
    std::string Status(bool long_file_description = true) override;
 
    int GetRunNumber() override;

--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -92,7 +92,6 @@ bool TLstFile::Open(const char* filename)
       in.seekg(headerSize, std::ifstream::beg);
       in.read(fReadBuffer.data(), fFileSize);
       in.close();
-
    } catch(std::exception& e) {
       std::cout<<"Caught "<<e.what()<<std::endl;
    }
@@ -140,6 +139,12 @@ int TLstFile::Read(std::shared_ptr<TRawEvent> lstEvent)
       return fFileSize;
    }
    return 0;
+}
+
+void TLstFile::Skip(size_t)
+{
+	std::cerr<<"Sorry, but we can't skip events in an LST file, the whole file is treated as a single event!"<<std::endl;
+	return;
 }
 
 int TLstFile::GetRunNumber()


### PR DESCRIPTION
Lst files are read completely into memory before processing and do not have an event structure written in them. Since we do not have an easy way to skip data without removing coincidences, we just do not implement the function.