### PR TITLE
Wip/header

### DIFF
--- a/include/TILLDataParser.h
+++ b/include/TILLDataParser.h
@@ -48,6 +48,15 @@ public:
    // ENUM(EBank, char, kWFDN,kGRF1,kGRF2,kGRF3,kFME0,kFME1,kFME2,kFME3);
    enum class EBank { kWFDN = 0, kGRF1 = 1, kGRF2 = 2, kGRF3 = 3, kGRF4 = 4, kFME0 = 5, kFME1 = 6, kFME2 = 7, kFME3 = 8 };
 
+   enum class EDigitizer {
+       kV1751 = 1,
+       kV1724 = 2,
+       kV1730_PSD = 3,
+       kV1730_PHA = 4,
+       kV1725_PHA = 7,
+       kV1725_PSD = 8
+   };
+
    enum class EDataParserState {
       kGood,
       kBadHeader,

--- a/include/TLstFile.h
+++ b/include/TLstFile.h
@@ -26,7 +26,7 @@
 
 #include "TLstEvent.h"
 
-/// Reader for MIDAS .mid files
+/// Reader for ILL .lst files
 
 class TLstFile : public TRawFile {
 public:
@@ -52,6 +52,12 @@ public:
 #ifndef __CINT__
    std::shared_ptr<TRawEvent> NewEvent() override { return std::make_shared<TLstEvent>(); }
 #endif
+private:
+   int32_t fVersion;
+   int32_t fTimeBase;
+   int32_t fnbEvents;
+   int32_t fnbBoards;
+   int32_t* fBoardHeaders;
 
 protected:
    /// \cond CLASSIMP

--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -45,6 +45,8 @@ TLstFile::TLstFile(const char* filename, TRawFile::EOpenType open_type) : TLstFi
 TLstFile::~TLstFile()
 {
    // Default dtor. It closes the read in lst file as well as the output lst file.
+   if( fBoardHeaders != nullptr )
+       delete fBoardHeaders;
    Close();
 }
 


### PR DESCRIPTION
Changed TLstFile to read in the header information of a .lst file. Before, it was assumed that .lst headers were a fixed size. However, the size of the header depends on the number of boards used during the run.

Some of the information collected from the header would be useful to pass onto the data parser to correctly parse the events of different boards. ie, different masks for charge, timestamp, etc. But, I'm not sure of a clean way to pass on that information. At the moment, the data is just stored as member variables of the TLstFile Class after reading a .lst file.

-- Kurtis