### PR TITLE
Detector information change from map to unordered map

### DIFF
--- a/libraries/TILLFormat/TILLDetectorInformation.cxx
+++ b/libraries/TILLFormat/TILLDetectorInformation.cxx
@@ -1,6 +1,7 @@
 #include "TILLDetectorInformation.h"
 
 #include <iostream>
+#include <unordered_map>
 
 #include "TROOT.h"
 
@@ -47,7 +48,7 @@ void TILLDetectorInformation::Clear(Option_t*)
 void TILLDetectorInformation::Set()
 {
    /// Sets the run info. This figures out what systems are available.
-   std::map<unsigned int, TChannel*>::iterator iter;
+   std::unordered_map<unsigned int, TChannel*>::iterator iter;
    for(iter = TChannel::GetChannelMap()->begin(); iter != TChannel::GetChannelMap()->end(); iter++) {
       std::string channelname = iter->second->GetName();
 


### PR DESCRIPTION
Detector information change from map to unordered map in order to work with most up-to-date version of GRSISort