### PR TITLE
Update/detectors

### DIFF
--- a/include/TFippsBgo.h
+++ b/include/TFippsBgo.h
@@ -1,0 +1,24 @@
+#ifndef TFIPPSBGO_H
+#define TFIPPSBGO_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include "Globals.h"
+#include "TBgo.h"
+
+class TFippsBgo : public TBgo {
+public:
+   TFippsBgo();
+   TFippsBgo(const TFippsBgo&);
+   virtual ~TFippsBgo();
+
+   TFippsBgo& operator=(const TFippsBgo&); //!<!
+
+   /// \cond CLASSIMP
+   ClassDef(TFippsBgo, 1) // GriffinBgo Physics structure
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsBgoHit.h
+++ b/include/TFippsBgoHit.h
@@ -1,0 +1,39 @@
+#ifndef TFIPPSBGOHIT_H
+#define TFIPPSBGOHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <cstdio>
+#include <cmath>
+#if !defined(__CINT__) && !defined(__CLING__)
+#include <tuple>
+#endif
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TClonesArray.h"
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TPulseAnalyzer.h"
+
+#include "TBgoHit.h"
+
+class TFippsBgoHit : public TBgoHit {
+public:
+   TFippsBgoHit();
+   TFippsBgoHit(const TFippsBgoHit& hit) : TBgoHit(static_cast<const TBgoHit&>(hit)) {}
+   TFippsBgoHit(const TFragment& frag) : TBgoHit(frag) {}
+   ~TFippsBgoHit() override;
+
+   /////////////////////////		/////////////////////////////////////
+   UShort_t GetArrayNumber() const override { return (20 * (GetDetector() - 1) + 5 * GetCrystal() + GetSegment()); } //!<!
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsBgoHit, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsHit.h
+++ b/include/TFippsHit.h
@@ -43,7 +43,7 @@ public:
    TVector3 GetPosition() const override;
 
 private:
-   Double_t GetDefaultDistance() const { return 110.; }
+   Double_t GetDefaultDistance() const { return 90.; } // Target to detector distance is 90mm (Unless suppressed)
 
    /// \cond CLASSIMP
    ClassDefOverride(TFippsHit, 2); // Information about a FIPPS Hit

--- a/include/TFippsLaBr.h
+++ b/include/TFippsLaBr.h
@@ -1,0 +1,96 @@
+#ifndef TFIPPSLABR_H
+#define TFIPPSLABR_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////
+///
+/// \class TFippsLaBr
+///
+/// The TFippsLaBr class defines the observables and algorithms used
+/// when analyzing LaBr data. It includes detector positions,
+/// etc.
+///
+/////////////////////////////////////////////////////////////
+
+#include <vector>
+#include <cstdio>
+
+#include "TVector3.h"
+
+#include "Globals.h"
+#include "TSuppressed.h"
+#include "TTransientBits.h"
+#include "TFippsLaBrHit.h"
+
+class TFippsLaBr : public TSuppressed {
+public:
+   enum class ELaBrBits {
+      kIsSuppressed = 1<<0,
+      kBit1         = 1<<1,
+      kBit2         = 1<<2,
+      kBit3         = 1<<3,
+      kBit4         = 1<<4,
+      kBit5         = 1<<5,
+      kBit6         = 1<<6,
+      kBit7         = 1<<7
+   };
+
+   TFippsLaBr();
+   ~TFippsLaBr() override;
+   TFippsLaBr(const TFippsLaBr& rhs);
+
+   void Copy(TObject& rhs) const override;
+   TFippsLaBrHit* GetLaBrHit(const int& i) const { return static_cast<TFippsLaBrHit*>(GetHit(i)); }
+
+#if !defined(__CINT__) && !defined(__CLING__)
+   void SetSuppressionCriterion(std::function<bool(const TDetectorHit*, const TDetectorHit*)> criterion)
+   {
+      fSuppressionCriterion = std::move(criterion);
+   }
+   std::function<bool(const TDetectorHit*, const TDetectorHit*)> GetSuppressionCriterion() const { return fSuppressionCriterion; }
+
+   bool SuppressionCriterion(const TDetectorHit* hit, const TDetectorHit* bgoHit) override { return fSuppressionCriterion(hit, bgoHit); }
+#endif
+
+   TFippsLaBrHit* GetSuppressedHit(const int& i);                          //!<!
+   Short_t GetSuppressedMultiplicity(const TBgo* fBgo);
+   bool IsSuppressed() const;
+	void SetSuppressed(const bool flag);
+   void ResetSuppressed();
+
+#if !defined(__CINT__) && !defined(__CLING__)
+   void AddFragment(const std::shared_ptr<const TFragment>&, TChannel*) override; //!<!
+#endif
+	void BuildHits() override {} // no need to build any hits, everything already done in AddFragment
+
+   static TVector3 GetPosition(int DetNbr) { return gPosition[DetNbr]; } //!<!
+
+   TFippsLaBr& operator=(const TFippsLaBr&); //!<!
+
+private:
+#if !defined(__CINT__) && !defined(__CLING__)
+   static std::function<bool(const TDetectorHit*, const TDetectorHit*)> fSuppressionCriterion;
+#endif
+   std::vector<TDetectorHit*> fSuppressedHits; //   The set of suppressed LaBr hits
+
+   static TVector3 gPosition[9]; //!<!  Position of each detectir
+
+   mutable TTransientBits<UChar_t> fLaBrBits;  // Transient member flags
+
+   void ClearStatus() const { fLaBrBits = 0; } //!<!
+   void SetBitNumber(const ELaBrBits bit, const bool set) const { fLaBrBits.SetBit(bit, set); }
+   Bool_t TestBitNumber(const ELaBrBits bit) const { return fLaBrBits.TestBit(bit); }
+
+public:
+   void Clear(Option_t* opt = "") override;       //!<!
+   void Print(Option_t* opt = "") const override; //!<!
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsLaBr, 1) // LaBr Physics structure
+	/// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsLaBrBgo.h
+++ b/include/TFippsLaBrBgo.h
@@ -1,0 +1,24 @@
+#ifndef TLABRBGO_H
+#define TLABRBGO_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include "Globals.h"
+#include "TBgo.h"
+
+class TFippsLaBrBgo : public TBgo {
+public:
+   TFippsLaBrBgo();
+   TFippsLaBrBgo(const TFippsLaBrBgo&);
+   virtual ~TFippsLaBrBgo();
+
+   TFippsLaBrBgo& operator=(const TFippsLaBrBgo&); //!<!
+
+   /// \cond CLASSIMP
+   ClassDef(TFippsLaBrBgo, 1) // LaBrBgo Physics structure
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsLaBrBgoHit.h
+++ b/include/TFippsLaBrBgoHit.h
@@ -1,0 +1,39 @@
+#ifndef TFIPPSLABRBGOHIT_H
+#define TFIPPSLABRBGOHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <cstdio>
+#include <cmath>
+#if !defined(__CINT__) && !defined(__CLING__)
+#include <tuple>
+#endif
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TClonesArray.h"
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TPulseAnalyzer.h"
+
+#include "TBgoHit.h"
+
+class TFippsLaBrBgoHit : public TBgoHit {
+public:
+   TFippsLaBrBgoHit();
+   TFippsLaBrBgoHit(const TFippsLaBrBgoHit& hit) : TBgoHit(static_cast<const TBgoHit&>(hit)) {}
+   TFippsLaBrBgoHit(const TFragment& frag) : TBgoHit(frag) {}
+   ~TFippsLaBrBgoHit() override;
+
+   /////////////////////////		/////////////////////////////////////
+   UShort_t GetArrayNumber() const override { return (3 * (GetDetector() - 1) + GetSegment()); } //!<! the BGO of each detector has three segments
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsLaBrBgoHit, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsLaBrHit.h
+++ b/include/TFippsLaBrHit.h
@@ -1,0 +1,61 @@
+#ifndef LABRHIT_H
+#define LABRHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TFippsLaBrHit
+///
+/// This is class that contains the information about a LaBr
+/// hit. This class is used to find energy, time, etc.
+///
+/////////////////////////////////////////////////////////////////
+
+#include <cstdio>
+#include <cmath>
+
+#include "TFragment.h"
+#include "TChannel.h"
+
+#include "TVector3.h"
+
+#include "TFippsHit.h"
+
+class TFippsLaBrHit : public TFippsHit {
+public:
+   TFippsLaBrHit();
+   ~TFippsLaBrHit() override;
+   TFippsLaBrHit(const TFippsLaBrHit&);
+   TFippsLaBrHit(const TFragment& frag) : TFippsHit(frag) {}
+
+private:
+   Int_t fFilter{0};
+
+public:
+   /////////////////////////		/////////////////////////////////////
+   inline void SetFilterPattern(const int& x) { fFilter = x; } //!<!
+
+   /////////////////////////		/////////////////////////////////////
+   inline Int_t GetFilterPattern() const { return fFilter; } //!<!
+
+   bool InFilter(Int_t); //!<!
+
+public:
+   void Clear(Option_t* opt = "") override;       //!<!
+   void Print(Option_t* opt = "") const override; //!<!
+   void     Copy(TObject&) const override;        //!<!
+   TVector3 GetPosition(Double_t dist) const override;
+   TVector3 GetPosition() const override;
+
+private:
+   Double_t GetDefaultDistance() const { return 0.; } // This needs to be updated
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsLaBrHit, 2) // Stores the information for a LaBrrHit
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsPulser.h
+++ b/include/TFippsPulser.h
@@ -1,0 +1,39 @@
+#ifndef TFIPPSPULSER_H
+#define TFIPPSPULSER_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <iostream>
+
+#include "TDetector.h"
+#include "TChannel.h"
+#include "TILLDetectorHit.h"
+
+class TFippsPulser : public TDetector {
+public:
+
+   TFippsPulser();
+   TFippsPulser(const TFippsPulser&);
+   ~TFippsPulser() override;
+
+#ifndef __CINT__
+   void AddFragment(const std::shared_ptr<const TFragment>&, TChannel*) override; //!<!
+#endif
+	void BuildHits() override {} // no need to build any hits, everything already done in AddFragment
+
+   TILLDetectorHit* GetGenericDetectorHit(const int& i) const { return static_cast<TILLDetectorHit*>(GetHit(i)); }
+
+   TFippsPulser& operator=(const TFippsPulser&);                    //
+   void Print(Option_t* opt = "") const override; //!<!
+
+private:
+   void  ClearStatus() {  }
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsPulser, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsTAC.h
+++ b/include/TFippsTAC.h
@@ -1,0 +1,51 @@
+#ifndef TFIPPSTAC_H
+#define TFIPPSTAC_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////
+///
+/// \class TFippsTAC
+///
+/// The TFippsTAC class defines the observables and algorithms used
+/// when analyzing TAC data. It includes detector positions,
+/// etc.
+///
+/////////////////////////////////////////////////////////////
+
+#include <vector>
+#include <cstdio>
+
+#include "TVector3.h"
+
+#include "Globals.h"
+#include "TDetector.h"
+#include "TFippsTACHit.h"
+
+class TFippsTAC : public TDetector {
+public:
+   TFippsTAC();
+   ~TFippsTAC() override;
+   TFippsTAC(const TFippsTAC& rhs);
+
+public:
+   TFippsTACHit* GetTACHit(const int& i) const { return static_cast<TFippsTACHit*>(GetHit(i)); }
+
+#ifndef __CINT__
+   void AddFragment(const std::shared_ptr<const TFragment>&, TChannel*) override; //!<!
+#endif
+	void BuildHits() override {} // no need to build any hits, everything already done in AddFragment
+
+   TFippsTAC& operator=(const TFippsTAC&); //!<!
+
+public:
+   void Print(Option_t* opt = "") const override; //!<!
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsTAC, 1) // TAC Physics structure
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TFippsTACHit.h
+++ b/include/TFippsTACHit.h
@@ -1,0 +1,61 @@
+#ifndef FIPPSTACHIT_H
+#define FIPPSTACHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TFippsTACHit
+///
+/// This is class that contains the information about a TAC
+/// hit. This class is used to find energy, time, etc.
+///
+/////////////////////////////////////////////////////////////////
+
+#include <cstdio>
+#include <cmath>
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TGraph.h"
+
+#include "TVector3.h"
+
+#include "TILLDetectorHit.h"
+
+class TFippsTACHit : public TILLDetectorHit {
+public:
+   TFippsTACHit();
+   ~TFippsTACHit() override;
+   TFippsTACHit(const TFippsTACHit&);
+   TFippsTACHit(const TFragment& frag) : TILLDetectorHit(frag) {}
+
+private:
+   Int_t fFilter{0};
+
+public:
+   /////////////////////////		/////////////////////////////////////
+   inline void SetFilterPattern(const int& x) { fFilter = x; } //!<!
+
+   /////////////////////////		/////////////////////////////////////
+   inline Int_t GetFilterPattern() const { return fFilter; } //!<!
+
+   bool InFilter(Int_t); //!<!
+
+   Double_t GetTempCorrectedCharge(TGraph* correction_graph) const;
+   Double_t TempCorrectedCharge(TGraph* correction_graph) const;
+   Double_t GetTempCorrectedEnergy(TGraph* correction_graph) const;
+
+public:
+   void Clear(Option_t* opt = "") override;       //!<!
+   void Print(Option_t* opt = "") const override; //!<!
+   void Copy(TObject&) const override;            //!<!
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TFippsTACHit, 1) // Stores the information for a TACrHit
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TILLDetectorInformation.h
+++ b/include/TILLDetectorInformation.h
@@ -32,14 +32,29 @@ public:
 	void Set() override;
 
    inline void SetFipps(bool flag = true)    { fFipps = flag; }
+   inline void SetFippsBgo(bool flag = true)    { fFippsBgo = flag; }
+   inline void SetFippsLaBr(bool flag = true)    { fFippsLaBr = flag; }
+   inline void SetFippsLaBrBgo(bool flag = true)    { fFippsLaBrBgo = flag; }
+   inline void SetFippsTAC(bool flag = true)    { fFippsTAC = flag; }
+   inline void SetFippsPulser(bool flag = true)    { fFippsPulser = flag; }
 
    inline bool Fipps()    const { return fFipps; }
+   inline bool FippsBgo()   const { return fFippsBgo; }
+   inline bool FippsLaBr() const { return fFippsLaBr; }
+   inline bool FippsLaBrBgo() const { return fFippsLaBrBgo; }
+   inline bool FippsTAC() const { return fFippsTAC; }
+   inline bool FippsPulser() const { return fFippsPulser; }
 
 private:
    //  detector types to switch over in Set()
    //  for more info, see: https://www.triumf.info/wiki/tigwiki/index.php/Detector_Nomenclature
 
    bool fFipps{false}; // flag for Fipps on/off
+   bool fFippsBgo{false};
+   bool fFippsLaBr{false};
+   bool fFippsLaBrBgo{false};
+   bool fFippsTAC{false};
+   bool fFippsPulser{false};
 
    /// \cond CLASSIMP
    ClassDefOverride(TILLDetectorInformation, 1); // Contains the run-dependent information.

--- a/include/TILLMnemonic.h
+++ b/include/TILLMnemonic.h
@@ -6,7 +6,7 @@
 #include "Globals.h"
 #include "TClass.h"
 
-enum class EDigitizer : char { kDefault, kCAEN8, kCaen };
+enum class EDigitizer : char { kDefault, kV1724, kV1725, kV1730, kV1751 };
 
 class TILLMnemonic : public TMnemonic {
 public:
@@ -19,7 +19,12 @@ public:
    // These separations exist only to easily see the difference when looking at the code here.
    enum class ESystem {
       kFipps,           //0
-		kClear            //1
+      kFippsBgo,        //1
+      kFippsLaBr,       //2
+      kFippsLaBrBgo,    //3
+      kFippsTAC,        //4
+      kFippsPulser,
+      kClear          //6
    };
 
    ESystem   System() const { return fSystem; }

--- a/libraries/TILLAnalysis/TFipps/LinkDef.h
+++ b/libraries/TILLAnalysis/TFipps/LinkDef.h
@@ -1,4 +1,4 @@
-//TFipps.h TFippsHit.h 
+//TFipps.h TFippsHit.h TFippsBgo.h TFippsBgoHit.h
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -12,6 +12,9 @@
 #pragma link C++ class std::vector<TFippsHit>+;
 #pragma link C++ class std::vector<TFippsHit*>+;
 #pragma link C++ class TFipps+;
+#pragma link C++ class TFippsBgoHit+;
+#pragma link C++ class TFippsBgo+;
+
 
 #endif
 

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -423,6 +423,8 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
    // Set Theta's of the center of each DETECTOR face
    ////Define one Detector position
    TVector3 shift;
+   TVector3 DetectorCenter;
+   DetectorCenter.SetXYZ(0, 0, 1); // Center of the clover
    switch(CryNbr) {
    case 0: shift.SetXYZ(-cp, cp, id); break;
    case 1: shift.SetXYZ(cp, cp, id); break;
@@ -430,8 +432,10 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
    case 3: shift.SetXYZ(-cp, -cp, id); break;
    default: shift.SetXYZ(0, 0, 1); break;
    };
+   // Roate the crystal to where the detector is
    shift.RotateX(temp_pos.Theta());
-   shift.RotateY(temp_pos.Phi());
+   DetectorCenter.RotateX(temp_pos.Theta());
+   shift.RotateY(DetectorCenter.Angle(temp_pos));
 
    temp_pos.SetMag(dist);
 

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -33,73 +33,69 @@ bool DefaultFippsSuppression(const TDetectorHit* hit, const TDetectorHit* bgoHit
 
 std::function<bool(const TDetectorHit*, const TDetectorHit*)> TFipps::fSuppressionCriterion = DefaultFippsSuppression;
 
-// This seems unnecessary, and why 17?;//  they are static members, and need
-//  to be defined outside the header
-//  17 is to have the detectors go from 1-16
-//  plus we can use position zero
-//  when the detector winds up back in
-//  one of the stands like Alex used in the
-//  gps run. pcb.
-// Initiallizes the HPGe Clover positions as per the wiki
-// <https://www.triumf.info/wiki/tigwiki/index.php/HPGe_Coordinate_Table>
-//                                                                             theta                                 phi
-//                                                                             theta                                phi
-//                                                                             theta
+// Fipps detector locations.
+// Angles are in ISO standard
+// x = cos(theta)*sin(phi)      // Points port
+// y = sin(theta)*sin(phi)      // Points upwards
+// z = sin(theta)               // Points in the direction of the neutrons
+// TVector(x,y,z)
+// TODO: Add link to picture showing detector positions when uploaded
 TVector3 TFipps::gCloverPosition[17] = {
    TVector3(TMath::Sin(TMath::DegToRad() * (0.0)) * TMath::Cos(TMath::DegToRad() * (0.0)),
             TMath::Sin(TMath::DegToRad() * (0.0)) * TMath::Sin(TMath::DegToRad() * (0.0)),
-            TMath::Cos(TMath::DegToRad() * (0.0))),
-   // Downstream lampshade
-   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (67.5)),
-            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (67.5)),
-            TMath::Cos(TMath::DegToRad() * (45.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (157.5)),
-            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (157.5)),
-            TMath::Cos(TMath::DegToRad() * (45.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (247.5)),
-            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (247.5)),
-            TMath::Cos(TMath::DegToRad() * (45.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (337.5)),
-            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (337.5)),
-            TMath::Cos(TMath::DegToRad() * (45.0))),
+            TMath::Cos(TMath::DegToRad() * (0.0))), // Zeroth Position
    // Corona
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (22.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (22.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (67.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (67.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (112.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (112.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (157.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (157.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (202.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (202.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (247.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (247.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (292.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (292.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (337.5)),
-            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (337.5)),
-            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (90.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (90.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 0
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (45.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (45.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 1
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (0.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (0.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 2
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (315.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (315.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 3
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (270.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (270.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 4
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (225.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (225.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 5
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (180.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (180.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 6
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (135.0)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (135.0)),
+            TMath::Cos(TMath::DegToRad() * (90.0))), // Fipps Pos 7
+   // Downstream lampshade
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (90.0)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (90.0)),
+            TMath::Cos(TMath::DegToRad() * (45.0))), // Fipps Pos 8
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (0.0)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (0.0)),
+            TMath::Cos(TMath::DegToRad() * (45.0))), // Fipps Pos 9
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (270.0)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (270.0)),
+            TMath::Cos(TMath::DegToRad() * (45.0))), // Fipps Pos 10
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (180.0)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (180.0)),
+            TMath::Cos(TMath::DegToRad() * (45.0))), // Fipps Pos 11
    // Upstream lampshade
-   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (67.5)),
-            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (67.5)),
-            TMath::Cos(TMath::DegToRad() * (135.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (157.5)),
-            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (157.5)),
-            TMath::Cos(TMath::DegToRad() * (135.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (247.5)),
-            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (247.5)),
-            TMath::Cos(TMath::DegToRad() * (135.0))),
-   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (337.5)),
-            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (337.5)),
-            TMath::Cos(TMath::DegToRad() * (135.0)))};
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (90.0)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (90.0)),
+            TMath::Cos(TMath::DegToRad() * (135.0))), // G: 13 F: 12
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (0.0)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (0.0)),
+            TMath::Cos(TMath::DegToRad() * (135.0))), // G: 16 F: 13
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (270.0)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (270.0)),
+            TMath::Cos(TMath::DegToRad() * (135.0))), // G: 15 F: 14
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (180.0)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (180.0)),
+            TMath::Cos(TMath::DegToRad() * (135.0))) // G: 14 F: 15
+            };
 
 // Cross Talk stuff
 const Double_t TFipps::gStrongCT[2]           = {-0.02674, -0.000977}; // This is for the 0-1 and 2-3 combination
@@ -422,8 +418,8 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
 
    // Interaction points may eventually be set externally. May make these members of each crystal, or pass from
    // waveforms.
-   Double_t cp = 26.0; // Crystal Center Point  mm.
-   Double_t id = 45.0; // 45.0;  //Crystal interaction depth mm.
+   Double_t cp = 25.0; // Crystal Center Point  mm. (diameter 50mm)
+   Double_t id = 40.0; // Crystal interaction depth mm. (length 80mm)
    // Set Theta's of the center of each DETECTOR face
    ////Define one Detector position
    TVector3 shift;
@@ -434,8 +430,8 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
    case 3: shift.SetXYZ(-cp, -cp, id); break;
    default: shift.SetXYZ(0, 0, 1); break;
    };
-   shift.RotateY(temp_pos.Theta());
-   shift.RotateZ(temp_pos.Phi());
+   shift.RotateX(temp_pos.Theta());
+   shift.RotateY(temp_pos.Phi());
 
    temp_pos.SetMag(dist);
 

--- a/libraries/TILLAnalysis/TFipps/TFippsBgo.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFippsBgo.cxx
@@ -1,0 +1,48 @@
+#include "TFippsBgo.h"
+
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+
+#include "TRandom.h"
+#include "TMath.h"
+#include "TInterpreter.h"
+
+#include "TGRSIOptions.h"
+
+////////////////////////////////////////////////////////////
+//
+// TFippsBgo
+//
+// The TFippsBgo class is just a differently name TBgo.
+// This allows us to distinguish between the BGOs for diiferent
+// detector classes.
+//
+////////////////////////////////////////////////////////////
+
+/// \cond CLASSIMP
+ClassImp(TFippsBgo)
+/// \endcond
+
+TFippsBgo::TFippsBgo() : TBgo()
+{
+	/// Default ctor.
+   TBgo::Clear();
+}
+
+TFippsBgo::TFippsBgo(const TFippsBgo& rhs) : TBgo()
+{
+	/// Copy ctor.
+   rhs.Copy(*this);
+}
+
+TFippsBgo::~TFippsBgo()
+{
+   // Default Destructor
+}
+
+TFippsBgo& TFippsBgo::operator=(const TFippsBgo& rhs)
+{
+   rhs.Copy(*this);
+   return *this;
+}

--- a/libraries/TILLAnalysis/TFipps/TFippsBgoHit.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFippsBgoHit.cxx
@@ -1,0 +1,17 @@
+#include "TFippsBgoHit.h"
+
+#include "TClass.h"
+
+#include "GValue.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsBgoHit)
+/// \endcond
+
+TFippsBgoHit::TFippsBgoHit()
+{
+	Clear();
+}
+
+TFippsBgoHit::~TFippsBgoHit() = default;
+

--- a/libraries/TILLAnalysis/TFippsLaBr/LinkDef.h
+++ b/libraries/TILLAnalysis/TFippsLaBr/LinkDef.h
@@ -1,0 +1,17 @@
+//TFippsLaBr.h TFippsLaBrHit.h TFippsLaBrBgo.h TFippsLaBrBgoHit.h
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link off nestedclasses;
+
+
+#pragma link C++ class TFippsLaBrHit+;
+#pragma link C++ class std::vector<TFippsLaBrHit>+;
+#pragma link C++ class std::vector<TFippsLaBrHit*>+;
+#pragma link C++ class TFippsLaBr+;
+#pragma link C++ class TFippsLaBrBgoHit+;
+#pragma link C++ class TFippsLaBrBgo+;
+
+#endif

--- a/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBr.cxx
+++ b/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBr.cxx
@@ -1,0 +1,135 @@
+#include <iostream>
+#include "TFippsLaBr.h"
+#include <TRandom.h>
+#include <TMath.h>
+
+#include "TGRSIOptions.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsLaBr)
+/// \endcond
+
+bool DefaultLaBrSuppression(const TDetectorHit* hit, const TDetectorHit* bgoHit)
+{
+	return ((hit->GetDetector() == bgoHit->GetDetector()) &&
+	(std::fabs(hit->GetTime() - bgoHit->GetTime()) < TGRSIOptions::AnalysisOptions()->SuppressionWindow()) &&
+	(bgoHit->GetEnergy() > TGRSIOptions::AnalysisOptions()->SuppressionEnergy()));
+}
+
+std::function<bool(const TDetectorHit*, const TDetectorHit*)> TFippsLaBr::fSuppressionCriterion = DefaultLaBrSuppression;
+
+TVector3 TFippsLaBr::gPosition[9] = {
+	// These positions should be updated (they are currently SCEPTAR-ish)
+	TVector3(0, 0, 1),
+	TVector3(14.3025, 4.6472, 22.8096),
+	TVector3(0, 15.0386, 22.8096),
+	TVector3(-14.3025, 4.6472, 22.8096),
+	TVector3(-8.8395, -12.1665, 22.8096),
+	TVector3(8.8395, -12.1665, 22.8096),
+	TVector3(19.7051, 6.4026, 6.2123),
+	TVector3(0, 20.7192, 6.2123),
+	TVector3(-19.7051, 6.4026, 6.2123),
+};
+
+TFippsLaBr::TFippsLaBr()
+{
+	// Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	Clear();
+}
+
+TFippsLaBr::~TFippsLaBr()
+{
+	// Default Destructor
+}
+
+TFippsLaBr::TFippsLaBr(const TFippsLaBr& rhs) : TSuppressed()
+{
+	// Copy Contructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	rhs.Copy(*this);
+}
+
+void TFippsLaBr::Clear(Option_t* opt)
+{
+	// Clears all of the hits
+	TSuppressed::Clear(opt);
+	fSuppressedHits.clear();
+	fLaBrBits = 0;
+}
+
+void TFippsLaBr::Copy(TObject& rhs) const
+{
+	// Copies a TFippsLaBr
+	TSuppressed::Copy(rhs);
+
+	static_cast<TFippsLaBr&>(rhs).fSuppressedHits = fSuppressedHits;
+   static_cast<TFippsLaBr&>(rhs).fLaBrBits       = 0;
+}
+
+TFippsLaBr& TFippsLaBr::operator=(const TFippsLaBr& rhs)
+{
+	rhs.Copy(*this);
+	return *this;
+}
+
+void TFippsLaBr::Print(Option_t*) const
+{
+	// Prints out TFippsLaBr Multiplicity, currently does little.
+	printf("%lu fHits\n", fHits.size());
+}
+
+bool TFippsLaBr::IsSuppressed() const
+{
+	return TestBitNumber(ELaBrBits::kIsSuppressed);
+}
+
+void TFippsLaBr::SetSuppressed(const bool flag)
+{
+	return SetBitNumber(ELaBrBits::kIsSuppressed, flag);
+}
+
+void TFippsLaBr::ResetSuppressed()
+{
+   SetSuppressed(false);
+   fSuppressedHits.clear();
+}
+
+Short_t TFippsLaBr::GetSuppressedMultiplicity(const TBgo* bgo)
+{
+	/// Automatically builds the suppressed hits using the fSuppressionCriterion and returns the number of suppressed hits
+	if(fHits.empty()) {
+		return 0;
+	}
+   // if the suppressed has been reset, clear the suppressed hits
+   if(!IsSuppressed()) {
+      fSuppressedHits.clear();
+   }
+   if(fSuppressedHits.empty()) {
+		CreateSuppressed(bgo, fHits, fSuppressedHits);
+      SetSuppressed(true);
+   }
+
+   return fSuppressedHits.size();
+}
+
+TFippsLaBrHit* TFippsLaBr::GetSuppressedHit(const int& i)
+{
+	try {
+		return static_cast<TFippsLaBrHit*>(fSuppressedHits.at(i));
+	} catch(const std::out_of_range& oor) {
+		std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
+      throw grsi::exit_exception(1);
+   }
+	return nullptr;
+}
+
+void TFippsLaBr::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
+{
+	TFippsLaBrHit* laHit = new TFippsLaBrHit(*frag);                 // Building is controlled in the constructor of the hit
+	fHits.push_back(std::move(laHit)); // use std::move for efficienciy since laHit loses scope here anyway
+}

--- a/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBrBgo.cxx
+++ b/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBrBgo.cxx
@@ -1,0 +1,48 @@
+#include "TFippsLaBrBgo.h"
+
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+
+#include "TRandom.h"
+#include "TMath.h"
+#include "TInterpreter.h"
+
+#include "TGRSIOptions.h"
+
+////////////////////////////////////////////////////////////
+//
+// TFippsLaBrBgo
+//
+// The TFippsLaBrBgo class is just a differently name TBgo.
+// This allows us to distinguish between the BGOs for diiferent
+// detector classes.
+//
+////////////////////////////////////////////////////////////
+
+/// \cond CLASSIMP
+ClassImp(TFippsLaBrBgo)
+/// \endcond
+
+TFippsLaBrBgo::TFippsLaBrBgo() : TBgo()
+{
+	/// Default ctor.
+   TBgo::Clear();
+}
+
+TFippsLaBrBgo::TFippsLaBrBgo(const TFippsLaBrBgo& rhs) : TBgo()
+{
+	/// Copy ctor.
+   rhs.Copy(*this);
+}
+
+TFippsLaBrBgo::~TFippsLaBrBgo()
+{
+   // Default Destructor
+}
+
+TFippsLaBrBgo& TFippsLaBrBgo::operator=(const TFippsLaBrBgo& rhs)
+{
+   rhs.Copy(*this);
+   return *this;
+}

--- a/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBrBgoHit.cxx
+++ b/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBrBgoHit.cxx
@@ -1,0 +1,17 @@
+#include "TFippsLaBrBgoHit.h"
+
+#include "TClass.h"
+
+#include "GValue.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsLaBrBgoHit)
+/// \endcond
+
+TFippsLaBrBgoHit::TFippsLaBrBgoHit()
+{
+   Clear();
+}
+
+TFippsLaBrBgoHit::~TFippsLaBrBgoHit() = default;
+

--- a/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBrHit.cxx
+++ b/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBrHit.cxx
@@ -1,0 +1,78 @@
+#include "TFippsLaBrHit.h"
+
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+#include "Globals.h"
+#include "TFippsLaBr.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsLaBrHit)
+/// \endcond
+
+TFippsLaBrHit::TFippsLaBrHit()
+{
+// Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+}
+
+TFippsLaBrHit::~TFippsLaBrHit() = default;
+
+TFippsLaBrHit::TFippsLaBrHit(const TFippsLaBrHit& rhs) : TFippsHit()
+{
+// Copy Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+   rhs.Copy(*this);
+}
+
+void TFippsLaBrHit::Copy(TObject& rhs) const
+{
+   // Copies a TFippsLaBrHit
+   TFippsHit::Copy(rhs);
+   static_cast<TFippsLaBrHit&>(rhs).fFilter = fFilter;
+}
+
+TVector3 TFippsLaBrHit::GetPosition(Double_t) const
+{
+   // Gets the position of the current TFippsLaBrHit
+   return TFippsLaBr::GetPosition(GetDetector());
+}
+
+TVector3 TFippsLaBrHit::GetPosition() const
+{
+   // Gets the position of the current TFippsLaBrHit
+   return GetPosition(GetDefaultDistance());
+}
+
+bool TFippsLaBrHit::InFilter(Int_t)
+{
+   // check if the desired filter is in wanted filter;
+   // return the answer;
+   // currently does nothing
+   return true;
+}
+
+void TFippsLaBrHit::Clear(Option_t*)
+{
+   // Clears the LaBrHit
+   fFilter = 0;
+   TFippsHit::Clear();
+}
+
+void TFippsLaBrHit::Print(Option_t*) const
+{
+   // Prints the LaBrHit. Returns:
+   // Detector
+   // Energy
+   // Time
+   printf("LaBr Detector: %i\n", GetDetector());
+   printf("LaBr hit energy: %.2f\n", GetEnergy());
+   printf("LaBr hit time:   %.lf\n", GetTime());
+}

--- a/libraries/TILLAnalysis/TFippsPulser/LinkDef.h
+++ b/libraries/TILLAnalysis/TFippsPulser/LinkDef.h
@@ -1,0 +1,18 @@
+// TFippsPulser.h
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+
+// #pragma link C++ class TILLDetectorHit+;
+// #pragma link C++ class std::vector<TILLDetectorHit>+;
+#pragma link C++ class TFippsPulser+;
+
+#endif
+
+
+
+
+

--- a/libraries/TILLAnalysis/TFippsPulser/TFippsPulser.cxx
+++ b/libraries/TILLAnalysis/TFippsPulser/TFippsPulser.cxx
@@ -1,0 +1,47 @@
+#include "TFippsPulser.h"
+
+#include "TClass.h"
+#include <cmath>
+#include "TMath.h"
+
+#include "TGRSIOptions.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsPulser)
+/// \endcond
+
+
+TFippsPulser::TFippsPulser()
+{
+   Clear();
+}
+
+TFippsPulser::~TFippsPulser() = default;
+
+TFippsPulser& TFippsPulser::operator=(const TFippsPulser& rhs)
+{
+   rhs.Copy(*this);
+   return *this;
+}
+
+TFippsPulser::TFippsPulser(const TFippsPulser& rhs) : TDetector()
+{
+   rhs.Copy(*this);
+}
+
+void TFippsPulser::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
+{
+	
+   /// This function creates TFippsPulserHits for each fragment and stores them in separate front and back vectors
+   if(frag == nullptr || chan == nullptr) {
+      return;
+   }
+
+   TILLDetectorHit* dethit = new TILLDetectorHit(*frag);
+   fHits.push_back(std::move(dethit));
+}
+
+void TFippsPulser::Print(Option_t*) const
+{
+   printf("%s\tnot yet written.\n", __PRETTY_FUNCTION__);
+}

--- a/libraries/TILLAnalysis/TFippsTAC/LinkDef.h
+++ b/libraries/TILLAnalysis/TFippsTAC/LinkDef.h
@@ -1,0 +1,19 @@
+//TFippsTAC.h TFippsTACHit.h 
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link off nestedclasses;
+
+
+#pragma link C++ class TFippsTACHit+;
+#pragma link C++ class std::vector<TFippsTACHit>+;
+#pragma link C++ class TFippsTAC+;
+
+#endif
+
+
+
+
+

--- a/libraries/TILLAnalysis/TFippsTAC/TFippsTAC.cxx
+++ b/libraries/TILLAnalysis/TFippsTAC/TFippsTAC.cxx
@@ -1,0 +1,49 @@
+#include "TFippsTAC.h"
+#include <iostream>
+#include "TRandom.h"
+#include "TMath.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsTAC)
+/// \endcond
+
+TFippsTAC::TFippsTAC()
+{
+	// Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	Clear();
+}
+
+TFippsTAC::~TFippsTAC()
+{
+	// Default Destructor
+}
+
+TFippsTAC::TFippsTAC(const TFippsTAC& rhs) : TDetector()
+{
+	// Copy Contructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	rhs.Copy(*this);
+}
+
+TFippsTAC& TFippsTAC::operator=(const TFippsTAC& rhs)
+{
+	rhs.Copy(*this);
+	return *this;
+}
+
+void TFippsTAC::Print(Option_t*) const
+{
+	// Prints out TFippsTAC Multiplicity, currently does little.
+	printf("%lu fHits\n", fHits.size());
+}
+
+void TFippsTAC::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
+{
+	TFippsTACHit* hit = new TFippsTACHit(*frag);
+	fHits.push_back(std::move(hit));
+}

--- a/libraries/TILLAnalysis/TFippsTAC/TFippsTACHit.cxx
+++ b/libraries/TILLAnalysis/TFippsTAC/TFippsTACHit.cxx
@@ -1,0 +1,102 @@
+#include "TFippsTACHit.h"
+
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+#include "Globals.h"
+#include "TFippsTAC.h"
+
+/// \cond CLASSIMP
+ClassImp(TFippsTACHit)
+/// \endcond
+
+TFippsTACHit::TFippsTACHit()
+{
+	// Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	Clear();
+}
+
+TFippsTACHit::~TFippsTACHit() = default;
+
+TFippsTACHit::TFippsTACHit(const TFippsTACHit& rhs) : TILLDetectorHit()
+{
+	// Copy Constructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	Clear();
+	rhs.Copy(*this);
+}
+
+void TFippsTACHit::Copy(TObject& rhs) const
+{
+	// Copies a TFippsTACHit
+	TILLDetectorHit::Copy(rhs);
+	static_cast<TFippsTACHit&>(rhs).fFilter = fFilter;
+}
+
+Double_t TFippsTACHit::GetTempCorrectedCharge(TGraph* correction_graph) const {
+	//Applies the kValue ot the charge
+	if(!correction_graph){
+		std::cout << "Graph for temperture corrections is null" << std::endl;
+	}
+
+	return GetCharge()*correction_graph->Eval(GetTime()/1e9);//The graph should be defined in seconds
+}
+
+Double_t TFippsTACHit::TempCorrectedCharge(TGraph* correction_graph) const {
+	//Returns the raw charge with no kValue applied
+	if(!correction_graph){
+		std::cout << "Graph for temperture corrections is null" << std::endl;
+	}
+
+	return Charge()*correction_graph->Eval(GetTime()/1e9);//The graph should be defined in seconds
+}
+
+Double_t TFippsTACHit::GetTempCorrectedEnergy(TGraph* correction_graph) const {
+	//This will not overwrite the normal energy, nor will it get stored as the energy.
+	if(!correction_graph){
+		std::cout << "Graph for temperture corrections is null" << std::endl;
+	}
+
+	TChannel* channel = GetChannel();
+	if(channel == nullptr) {
+		return 0.0;
+	}
+	if(fKValue > 0) {
+		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), (int)fKValue);
+	} else if(channel->UseCalFileIntegration()) {
+		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), 0);
+	}
+	return channel->CalibrateENG(TempCorrectedCharge(correction_graph));
+}
+
+bool TFippsTACHit::InFilter(Int_t)
+{
+	// check if the desired filter is in wanted filter;
+	// return the answer;
+	// currently does nothing
+	return true;
+}
+
+void TFippsTACHit::Clear(Option_t*)
+{
+	// Clears the TACHit
+	fFilter = 0;
+	TILLDetectorHit::Clear();
+}
+
+void TFippsTACHit::Print(Option_t*) const
+{
+	// Prints the TACHit. Returns:
+	// Detector
+	// Energy
+	// Time
+	printf("TAC Detector: %i\n", GetDetector());
+	printf("TAC hit energy: %.2f\n", GetEnergy());
+	printf("TAC hit time:   %.lf\n", GetTime());
+}

--- a/libraries/TILLFormat/TILLDetectorInformation.cxx
+++ b/libraries/TILLFormat/TILLDetectorInformation.cxx
@@ -30,6 +30,11 @@ void TILLDetectorInformation::Print(Option_t* opt) const
    // a: Print out more details.
    if(strchr(opt, 'a') != nullptr) {
       printf("\t\tFIPPS:            %s\n", Fipps() ? "true" : "false");
+      printf("\t\tFIPPSBGO:         %s\n", FippsBgo() ? "true" : "false");
+      printf("\t\tFIPPSLABR:        %s\n", FippsLaBr() ? "true" : "false");
+      printf("\t\tFIPPSLABRBGO:     %s\n", FippsLaBrBgo() ? "true" : "false");
+      printf("\t\tFIPPSTAC:         %s\n", FippsTAC() ? "true" : "false");
+      printf("\t\tFIPPSPULSER:      %s\n", FippsPulser() ? "true" : "false");
       printf("\n");
    }
 }
@@ -56,6 +61,21 @@ void TILLDetectorInformation::Set()
       switch(static_cast<const TILLMnemonic*>(iter->second->GetMnemonic())->System()) {
 			case TILLMnemonic::ESystem::kFipps:
 				SetFipps();
+				break;
+			case TILLMnemonic::ESystem::kFippsBgo:
+				SetFippsBgo();
+				break;
+			case TILLMnemonic::ESystem::kFippsLaBr:
+				SetFippsLaBr();
+				break;
+			case TILLMnemonic::ESystem::kFippsLaBrBgo:
+				SetFippsLaBrBgo();
+				break;
+			case TILLMnemonic::ESystem::kFippsTAC:
+				SetFippsTAC();
+				break;
+			case TILLMnemonic::ESystem::kFippsPulser:
+				SetFippsPulser();
 				break;
 			default:
 				break;

--- a/libraries/TILLFormat/TILLMnemonic.cxx
+++ b/libraries/TILLFormat/TILLMnemonic.cxx
@@ -4,6 +4,11 @@
 
 // Detector dependent includes
 #include "TFipps.h"
+#include "TFippsBgo.h"
+#include "TFippsLaBr.h"
+#include "TFippsLaBrBgo.h"
+#include "TFippsTAC.h"
+#include "TFippsPulser.h"
 
 ClassImp(TILLMnemonic)
 
@@ -18,7 +23,21 @@ void TILLMnemonic::EnumerateSystem()
    // Enumerating the fSystemString must come after the total mnemonic has been parsed as the details of other parts of
    // the mnemonic must be known
    if(fSystemString.compare("FI") == 0) {
-      fSystem = ESystem::kFipps;
+      if(SubSystem() == EMnemonic::kS) {
+         fSystem = ESystem::kFippsBgo;
+      } else {
+          fSystem = ESystem::kFipps;
+      }
+   } else if(fSystemString.compare("LB") == 0) {
+       if(SubSystem() == EMnemonic::kS ) {
+           fSystem = ESystem::kFippsLaBrBgo;
+       } else if(SubSystem() == EMnemonic::kT) {
+           fSystem = ESystem::kFippsTAC;
+       } else {
+           fSystem = ESystem::kFippsLaBr;
+       }
+   } else if(fSystemString.compare("PU") == 0) {
+       fSystem = ESystem::kFippsPulser;
    } else {
       fSystem = ESystem::kClear;
    }
@@ -30,12 +49,20 @@ void TILLMnemonic::EnumerateDigitizer(TPriorityValue<std::string>& digitizerName
 	std::transform(name.begin(), name.end(), name.begin(), ::toupper);
 	EDigitizer tmpType = EDigitizer::kDefault;
 	int tmpUnit = 10;
-	if(name.compare("CAEN8") == 0) {
-		tmpType = EDigitizer::kCAEN8;
-	} else if(name.compare("CAEN") == 0) {
-		tmpType = EDigitizer::kCaen;
-	} else {
-		std::cout<<"Warning, digitizer type '"<<name<<"' not recognized, options are 'CAEN8', and 'CAEN'!"<<std::endl;
+	if(name.compare("V1724") == 0) {
+		tmpType = EDigitizer::kV1724;
+        tmpUnit = 10;
+	} else if(name.compare("V1725") == 0) {
+        tmpType = EDigitizer::kV1725;
+        tmpUnit = 4; // ns
+    } else if(name.compare("V1730") == 0) {
+        tmpType = EDigitizer::kV1730;
+        tmpUnit = 2; // ns
+    } else if(name.compare("V1751") == 0) {
+        tmpType = EDigitizer::kV1751;
+        tmpUnit = 1; // ns
+    } else {
+		std::cout<<"Warning, digitizer type '"<<name<<"' not recognized, options are 'V1724', 'V1725', 'V1730', and 'V1751'!"<<std::endl;
 	}
 	digitizerType.Set(tmpType, digitizerName.Priority());
 	timeStampUnit.Set(tmpUnit, digitizerName.Priority());
@@ -72,7 +99,12 @@ TClass* TILLMnemonic::GetClassType() const
 	}
 
 	switch(System()) {
-		case ESystem::kFipps: fClassType = TFipps::Class(); break;
+		case ESystem::kFipps:        fClassType = TFipps::Class(); break;
+        case ESystem::kFippsBgo:     fClassType = TFippsBgo::Class(); break;
+        case ESystem::kFippsLaBr:    fClassType = TFippsLaBr::Class(); break;
+        case ESystem::kFippsLaBrBgo: fClassType = TFippsLaBrBgo::Class(); break;
+        case ESystem::kFippsTAC:     fClassType = TFippsTAC::Class(); break;
+        case ESystem::kFippsPulser:  fClassType = TFippsPulser::Class(); break;
 		default:              fClassType = nullptr;
 	};
 	return fClassType;


### PR DESCRIPTION
This request has a couple parts to it. Hopefully this isn't too big of a pull request.

Closes #8.

- Lots of detectors have been moved over from TGriffin to TFipps which may be relevant for future and current experiments using Fipps. There may be a little bit of fine tailoring, but at the moment the detector classes are fine. In particular, the classes for LaBr, TACs, and Bgos all produce spectra.

- Changed TFipps to inherent from TSuppressed, as experiment 3-17-20 uses suppressed clovers from IFIN. As far as I've tested, the new TFipps class is comparable with unsuppressed detectors. All the different detector modes work now.
 
- Added a class for pulsers. It's mnemonic is just PUX0#XX00X, the PU part and detector number are all that matter. I'm not really sure what this is used for, but it's present in data from one of the experiments we have.
 
- The digitizers have changed in the Mnemonic parser. I've added more types of digitizers used with lst files (all CAEN). Timestamp information is updated to reflect what the digitizers are each capable of. This breaks previous digitizers labels. However, the default digitizer's timestamp is 10ns, which is what the previous CAEN and CAEN8 had as their timestamps.

- As shown to be incorrect in #8, TFipps now has the correct detector positions. The positions of the crystals mapped in GRIFFIN are different in FIPPS see the images from #8. These crystal positions are also fixed. 

I believe that this pull request is independent from what will be done to read headers in #7 .