### PR TITLE
Detector/crystal positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The data parser is set up to process FIPPS data written in the lst data format.
 Several detector classes are implimented: Fipps HPGe (TFipps), LaBr (TFippsLaBr), TAC (TFippsTAC), etc.
 
 Other classes included are:
- - the file and event classes for LST files,
- - the TILLMnemonic class which provides an enumeration for the detector systems and digitizers,
- - the TILLDetectorInformation which only provides functions to tell whether FIPPS data is present (which should be all the time), and
- - the TILLDetectorHit, which implemements the algorithm for how to get the time in nanoseconds from the timestamp and CFD information.
+ - File and event classes for LST files,
+ - TILLMnemonic, which provides an enumeration for the detector systems and digitizers,
+ - TILLDetectorInformation, which only provides functions to tell whether FIPPS data is present (which should be all the time), and
+ - TILLDetectorHit, which implemements the algorithm for how to get the time in nanoseconds from the timestamp and CFD information.
 
 ## Cal Information
 
@@ -32,4 +32,4 @@ In order to match the GRIFFIN clover colors to the FIPPS clover numbers the foll
 | 2                  | White          |
 | 3                  | Red            |
 
-If the stated rules are followed, there should be a 1-to-1 relationship between the GRIFFIN crystals and FIPPS crytals (relative to eachother). 
+If the stated rules are followed, there should be a 1-to-1 relationship between the GRIFFIN crystals and FIPPS crystals from the targets frame of reference. 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,31 @@ The names of the classes typically start with TILL.
 
 The data parser is set up to process FIPPS data written in the lst data format.
 
-The only detector class implemented is TFipps (and TFippsHit).
+Several detector classes are implimented: Fipps HPGe (TFipps), LaBr (TFippsLaBr), TAC (TFippsTAC), etc.
 
 Other classes included are:
  - the file and event classes for LST files,
  - the TILLMnemonic class which provides an enumeration for the detector systems and digitizers,
  - the TILLDetectorInformation which only provides functions to tell whether FIPPS data is present (which should be all the time), and
  - the TILLDetectorHit, which implemements the algorithm for how to get the time in nanoseconds from the timestamp and CFD information.
+
+## Cal Information
+
+The most of the detector nomenclature of ILLData follows the [GRSI wiki](https://grsi.wiki.triumf.ca/index.php/Detector_Nomenclature). The exceptions are:
+ - **FI** denotes the TFipps system
+ - **PU** denotes a pulser, and is based on the Generic Detector system
+
+## Transfering Fipps LUTs to Cal files
+
+Fipps detectors are labeled from 0 to 15, while the detector numbering in the cal file are labeled from 1 to 16. Fipps detector numbers from the experiment LUTs should be incremented by one and then inputed into the cal file.
+
+In order to match the GRIFFIN clover colors to the FIPPS clover numbers the following table should be used:
+
+| FIPPS Clover Label | Cal File Color |
+|:------------------:|:--------------:|
+| 0                  | Green          |
+| 1                  | Blue           |
+| 2                  | White          |
+| 3                  | Red            |
+
+If the stated rules are followed, there should be a 1-to-1 relationship between the GRIFFIN crystals and FIPPS crytals (relative to eachother). 

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -414,13 +414,11 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
       return TVector3(0, 0, 1);
    }
 
-   TVector3 temp_pos(gCloverPosition[DetNbr]);
+   TVector3 CloverPosition(gCloverPosition[DetNbr]);
 
-   // The axis represent:
    // XAxis: Array's Port
    // YAxis: Upwards
    // ZAxis: Points in the neutron beam direction
-   TVector3 XAxis(1,0,0); TVector3 YAxis(0,1,0); TVector3 ZAxis(0, 0, 1);
 
    // Interaction points may eventually be set externally. May make these members of each crystal, or pass from
    // waveforms.
@@ -428,29 +426,22 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
    Double_t id = 40.0; // Crystal interaction depth mm. (length 80mm)
    // Set Theta's of the center of each DETECTOR face
    ////Define one Detector position
-   TVector3 shift; TVector3 DetectorCenter;
+   TVector3 CrystalPosition;
    switch(CryNbr) {
-   case 0: shift.SetXYZ(-cp, cp, id); break;
-   case 1: shift.SetXYZ(cp, cp, id); break;
-   case 2: shift.SetXYZ(cp, -cp, id); break;
-   case 3: shift.SetXYZ(-cp, -cp, id); break;
-   default: shift.SetXYZ(0, 0, 1); break;
+   case 0: CrystalPosition.SetXYZ(-cp, cp, id); break;
+   case 1: CrystalPosition.SetXYZ(cp, cp, id); break;
+   case 2: CrystalPosition.SetXYZ(cp, -cp, id); break;
+   case 3: CrystalPosition.SetXYZ(-cp, -cp, id); break;
+   default: CrystalPosition.SetXYZ(0, 0, 1); break;
    };
-   DetectorCenter.SetXYZ(0, 0, 1);
-   // Rotate in the XZ plain to where the detector is
-   TVector3 XZProjection = temp_pos - (temp_pos*YAxis)*YAxis;
-   Double_t YRotationAngle = XZProjection.Angle(ZAxis);
-   shift.RotateY(YRotationAngle);
-   DetectorCenter.RotateY(YRotationAngle);
+   // Rotate counterclockwise from the downstream position
+   CrystalPosition.RotateX(-CloverPosition.Theta());
+   // Rotate around the neutron beam
+   CrystalPosition.RotateZ(CloverPosition.Phi());
+   // Set distance of detector from target
+   CloverPosition.SetMag(dist);
 
-   // Rotate upto the angle of the detector
-   Double_t RotationAngle = DetectorCenter.Angle(temp_pos);
-   TVector3 RotationAxis = DetectorCenter.Cross(temp_pos).Unit();
-   shift.Rotate( RotationAngle, RotationAxis );
-
-   temp_pos.SetMag(dist);
-
-   return (temp_pos + shift);
+   return (CloverPosition + CrystalPosition);
 }
 
 void TFipps::ResetFlags() const

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -428,10 +428,10 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
    ////Define one Detector position
    TVector3 CrystalPosition;
    switch(CryNbr) {
-   case 0: CrystalPosition.SetXYZ(-cp, cp, id); break;
-   case 1: CrystalPosition.SetXYZ(cp, cp, id); break;
-   case 2: CrystalPosition.SetXYZ(cp, -cp, id); break;
-   case 3: CrystalPosition.SetXYZ(-cp, -cp, id); break;
+   case 0: CrystalPosition.SetXYZ(-cp, cp, id); break;  // BLUE
+   case 1: CrystalPosition.SetXYZ(cp, cp, id); break;   // GREEN
+   case 2: CrystalPosition.SetXYZ(cp, -cp, id); break;  // RED
+   case 3: CrystalPosition.SetXYZ(-cp, -cp, id); break; // WHITE
    default: CrystalPosition.SetXYZ(0, 0, 1); break;
    };
    // Rotate counterclockwise from the downstream position


### PR DESCRIPTION
After thinking about the way I did the detector positions over the weekend, I realized that I was reading the diagram from #8 wrong. I was fixed on the wording "as seen from target."

The clovers are relative to the neutron beam (Z-Axis) just like they are on GRIFFIN. What I had before was over complicated and wrong. The positions are now correct, and are found in a way that is exactly analogous to GRIFFIN. I'm confident in this implementation.

The README is also updated with not only some minor proofreading, but it also contains two sections for converting the LUTs provided with FIPPS experiments to what can be used by this library. And hence most of the programs put forth from the GRSI.