### PR TITLE
Fix/crystal positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ In order to match the GRIFFIN clover colors to the FIPPS clover numbers the foll
 
 | FIPPS Clover Label | Cal File Color |
 |:------------------:|:--------------:|
-| 0                  | Green          |
-| 1                  | Blue           |
-| 2                  | White          |
-| 3                  | Red            |
+| 0                  | Red            |
+| 1                  | White          |
+| 2                  | Blue           |
+| 3                  | Green          |
 
 If the stated rules are followed, there should be a 1-to-1 relationship between the GRIFFIN crystals and FIPPS crystals from the targets frame of reference. 

--- a/include/TFipps.h
+++ b/include/TFipps.h
@@ -111,9 +111,9 @@ private:
 
 public:
    // static bool SetBGOHits()       { return fSetBGOHits;   }  //!<!
+   static TVector3 gCloverPosition[17];                    //!<! Position of each HPGe Clover
 
 private:
-   static TVector3 gCloverPosition[17];                    //!<! Position of each HPGe Clover
    void            ClearStatus() const { fFippsBits = 0; } //!<!
    void SetBitNumber(EFippsBits bit, Bool_t set) const;
    Bool_t TestBitNumber(EFippsBits bit) const { return fFippsBits.TestBit(bit); }

--- a/include/TFipps.h
+++ b/include/TFipps.h
@@ -49,7 +49,7 @@ public:
 public:
    TDetectorHit* GetFippsHit(const Int_t& i);
 
-   static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double dist = 110.0); //!<!
+   static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double dist = 90.0); //!<!
 #ifndef __CINT__
    void AddFragment(const std::shared_ptr<const TFragment>&, TChannel*) override; //!<!
 #endif
@@ -111,9 +111,9 @@ private:
 
 public:
    // static bool SetBGOHits()       { return fSetBGOHits;   }  //!<!
-   static TVector3 gCloverPosition[17];                    //!<! Position of each HPGe Clover
 
 private:
+   static TVector3 gCloverPosition[17];                    //!<! Position of each HPGe Clover
    void            ClearStatus() const { fFippsBits = 0; } //!<!
    void SetBitNumber(EFippsBits bit, Bool_t set) const;
    Bool_t TestBitNumber(EFippsBits bit) const { return fFippsBits.TestBit(bit); }

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -435,7 +435,7 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
    default: CrystalPosition.SetXYZ(0, 0, 1); break;
    };
    // Rotate counterclockwise from the downstream position
-   CrystalPosition.RotateX(-CloverPosition.Theta());
+   CrystalPosition.RotateY(CloverPosition.Theta());
    // Rotate around the neutron beam
    CrystalPosition.RotateZ(CloverPosition.Phi());
    // Set distance of detector from target

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -422,7 +422,7 @@ TVector3 TFipps::GetPosition(int DetNbr, int CryNbr, double dist)
 
    // Interaction points may eventually be set externally. May make these members of each crystal, or pass from
    // waveforms.
-   Double_t cp = 25.0; // Crystal Center Point  mm. (diameter 50mm)
+   Double_t cp = 17.678;//25.0; // Crystal Center Point  mm. (diameter 50mm)
    Double_t id = 40.0; // Crystal interaction depth mm. (length 80mm)
    // Set Theta's of the center of each DETECTOR face
    ////Define one Detector position


### PR DESCRIPTION
I've spent a bit of time playing around with angular correlations with FIPPS and noticed I made an error in rotating the crystal positions.

By rotating by the X-Axis, instead of the Y-Axis, I unknowingly shifted the phi co-ordinate from 0° to 90°. After when rotating by the Z-Axis (Beam axis), the vectors were off by 90° from where they should be and the addition of the two vectors made from some really odd angles.