### PR TITLE
Wip/input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ Other classes included are:
  - TILLDetectorInformation, which only provides functions to tell whether FIPPS data is present (which should be all the time), and
  - TILLDetectorHit, which implemements the algorithm for how to get the time in nanoseconds from the timestamp and CFD information.
 
+## Installation
+
+To compile simply call ```make``` from inside the ILLData directory.
+
+Tested with GRSISort ```v4.0.0.1``` and ROOT ```v16.18/04```.
+
 ## Cal Information
+
 
 The most of the detector nomenclature of ILLData follows the [GRSI wiki](https://grsi.wiki.triumf.ca/index.php/Detector_Nomenclature). The exceptions are:
  - **FI** denotes the TFipps system
@@ -33,5 +40,3 @@ In order to match the GRIFFIN clover colors to the FIPPS clover numbers the foll
 | 3                  | Green          |
 
 If the stated rules are followed, there should be a 1-to-1 relationship between the GRIFFIN crystals and FIPPS crystals from the targets frame of reference. 
-
-To compile simply call ```make``` from inside the ILLData directory.

--- a/include/TILLDataParser.h
+++ b/include/TILLDataParser.h
@@ -88,8 +88,8 @@ public:
 #endif
 
 private:
-   int V1SingleFippsEventToFragment(char* data);
-   int V2SingleFippsEventToFragment(char* data);
+   int V1SingleFippsEventToFragment(uint32_t* data);
+   int V2SingleFippsEventToFragment(uint32_t* data);
 
 	EDataParserState fState;
 };

--- a/include/TILLDataParser.h
+++ b/include/TILLDataParser.h
@@ -88,7 +88,8 @@ public:
 #endif
 
 private:
-	int FippsToFragment(char* data, uint32_t size);
+   int V1SingleFippsEventToFragment(char* data);
+   int V2SingleFippsEventToFragment(char* data);
 
 	EDataParserState fState;
 };

--- a/include/TLstEvent.h
+++ b/include/TLstEvent.h
@@ -37,13 +37,15 @@ public:
    // helpers for event creation
 
    char* GetData() override; ///< return pointer to the data buffer
-
    void SetData(std::vector<char>& buffer); ///< set an externally allocated data buffer
+   void SetLstVersion(int8_t version) { fLstVersion = version };
+   int8_t GetLstVersion() { return fLstVersion };
 
    int SwapBytes(bool) override; ///< convert event data between little-endian (Linux-x86) and big endian (MacOS-PPC)
 
 protected:
    std::vector<char> fData; ///< event data buffer
+   int8_t fLstVersion; ///< Lst version
 
    /// \cond CLASSIMP
    ClassDefOverride(TLstEvent, 0) // All of the data contained in a Midas Event

--- a/include/TLstEvent.h
+++ b/include/TLstEvent.h
@@ -38,14 +38,14 @@ public:
 
    char* GetData() override; ///< return pointer to the data buffer
    void SetData(std::vector<char>& buffer); ///< set an externally allocated data buffer
-   void SetLstVersion(int8_t version) { fLstVersion = version };
-   int8_t GetLstVersion() { return fLstVersion };
+   void SetLstVersion(int32_t version) { fLstVersion = version; };
+   int8_t GetLstVersion() { return fLstVersion; };
 
    int SwapBytes(bool) override; ///< convert event data between little-endian (Linux-x86) and big endian (MacOS-PPC)
 
 protected:
    std::vector<char> fData; ///< event data buffer
-   int8_t fLstVersion; ///< Lst version
+   int32_t fLstVersion = 1; ///< Lst version
 
    /// \cond CLASSIMP
    ClassDefOverride(TLstEvent, 0) // All of the data contained in a Midas Event

--- a/include/TLstFile.h
+++ b/include/TLstFile.h
@@ -58,6 +58,7 @@ private:
    int32_t fnbEvents;
    int32_t fnbBoards;
    int32_t* fBoardHeaders;
+   std::ifstream fInputStream;
 
 protected:
    /// \cond CLASSIMP

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -132,14 +132,23 @@ void TFipps::Copy(TObject& rhs) const
    // Copy function.
    TSuppressed::Copy(rhs);
 
-   static_cast<TFipps&>(rhs).fAddbackHits  = fAddbackHits;
-   static_cast<TFipps&>(rhs).fAddbackFrags = fAddbackFrags;
+   static_cast<TFipps&>(rhs).fAddbackHits.clear();
+   static_cast<TFipps&>(rhs).fAddbackFrags.clear();
+   static_cast<TFipps&>(rhs).fSuppressedHits.clear();
+   static_cast<TFipps&>(rhs).fSuppressedAddbackHits.clear();
+   static_cast<TFipps&>(rhs).fSuppressedAddbackFrags.clear();
    static_cast<TFipps&>(rhs).fFippsBits    = 0;
 }
 
 TFipps::~TFipps()
 {
    // Default Destructor
+
+   // fHits automatically deleted in TDetector
+   for( auto hit : fAddbackHits ) delete hit;
+   for( auto hit : fSuppressedHits ) delete hit;
+   for( auto hit : fSuppressedAddbackHits ) delete hit;
+
 }
 
 void TFipps::Clear(Option_t* opt)
@@ -147,8 +156,17 @@ void TFipps::Clear(Option_t* opt)
    // Clears the mother, and all of the hits
    ClearStatus();
    TSuppressed::Clear(opt);
+
+
+   for( auto hit : fAddbackHits ) delete hit;
+   for( auto hit : fSuppressedHits ) delete hit;
+   for( auto hit : fSuppressedAddbackHits ) delete hit;
+
    fAddbackHits.clear();
+   fSuppressedHits.clear();
+   fSuppressedAddbackHits.clear();
    fAddbackFrags.clear();
+   fSuppressedAddbackFrags.clear();
 }
 
 void TFipps::Print(Option_t*) const

--- a/libraries/TILLDataParser/TILLDataParser.cxx
+++ b/libraries/TILLDataParser/TILLDataParser.cxx
@@ -37,7 +37,7 @@ int TILLDataParser::Process(std::shared_ptr<TRawEvent> rawEvent)
    uint32_t* EvntData = reinterpret_cast<uint32_t*>(event->GetData());
 
    if( fInputSize != nullptr )
-      *fInputSize += event->GetDataSize()/4; // 16 bytes per event, number of bytes in 32bits
+      *fInputSize += event->GetDataSize()/16; // 16 bytes per event, number of bytes in 32bits
 
    if( event->GetLstVersion() == 1 ) {
       for( size_t i = 0; i + 3 < size/4; i += 4 ) {
@@ -91,7 +91,7 @@ int TILLDataParser::V1SingleFippsEventToFragment(uint32_t* data)
          TParsingDiagnostics::Get()->BadFragment(99);
       }
       Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, 4, 2, false));
-      return 0;
+      return 1;
    }
    // Good event
    eventFrag->SetCharge(static_cast<int32_t>(Charge) );
@@ -122,7 +122,7 @@ int TILLDataParser::V2SingleFippsEventToFragment(uint32_t* data)
          TParsingDiagnostics::Get()->BadFragment(99);
       }
       Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, 4, 2, false));
-      return 0;
+      return 1;
    }
    // Good event
    eventFrag->SetCharge(static_cast<int32_t>(Charge) );

--- a/libraries/TILLDataParser/TILLDataParser.cxx
+++ b/libraries/TILLDataParser/TILLDataParser.cxx
@@ -32,7 +32,6 @@ int TILLDataParser::Process(std::shared_ptr<TRawEvent> rawEvent)
    // right now the parser only returns the total number of fragments read
    // so we assume (for now) that all fragments are good fragments
    int EventsProcessed = 0;
-   uint32_t NumberOfEventChunks = rawEvent->GetDataSize()/16;
    uint32_t size = event->GetDataSize();
    uint32_t* EvntData = reinterpret_cast<uint32_t*>(event->GetData());
 

--- a/libraries/TILLDataParser/TILLDataParser.cxx
+++ b/libraries/TILLDataParser/TILLDataParser.cxx
@@ -30,80 +30,102 @@ int TILLDataParser::Process(std::shared_ptr<TRawEvent> rawEvent)
    /// Returns the total number of fragments read (good and bad).
    // right now the parser only returns the total number of fragments read
    // so we assume (for now) that all fragments are good fragments
+   int EventsProcessed = 0;
 	std::shared_ptr<TLstEvent> event = std::static_pointer_cast<TLstEvent>(rawEvent);
-   return FippsToFragment(event->GetData(), event->GetDataSize());
+   if( fInputSize != nullptr )
+      *fInputSize += event->GetDataSize()/16 // 16 bytes per event
+   if( event->GetLstVersion() == 1 ) {
+      for( size_t i = 0; i + 3 < size / 4; i += 4 ) {
+         EventsProcessed += V1SingleFippsEventToFragment(event->GetData() + i);
+         if(fItemsPopped != nullptr && fInputSize != nullptr) {
+            ++(*fItemsPopped);
+            --(*fInputSize);
+         }
+      }
+   } else {
+      for( size_t i = 0; i + 3 < size / 4; i += 4 ) {
+         EventsProcessed += V2SingleFippsEventToFragment(event->GetData() + i);
+         if(fItemsPopped != nullptr && fInputSize != nullptr) {
+            ++(*fItemsPopped);
+            --(*fInputSize);
+         }
+      }
+   }
+
+   return EventsProcessed;
 }
 
-int TILLDataParser::FippsToFragment(char* data, uint32_t size)
+int TILLDataParser::V1SingleFippsEventToFragment(char* data)
 {
    uint32_t* ptr = reinterpret_cast<uint32_t*>(data);
-
-   int                        totalEventsRead = 0;
    std::shared_ptr<TFragment> eventFrag       = std::make_shared<TFragment>();
    Long64_t                   tmpTimestamp;
-   if(fItemsPopped != nullptr && fInputSize != nullptr) {
-      *fItemsPopped += 0;
-      *fInputSize   += size/16; //4 words of 4 bytes for each event
+
+   eventFrag->SetAddress( (ptr[0] >> 16) & 0xffff );
+
+   // Rollover, constant beween boards
+   tmpTimestamp = ptr[0] & 0xffff;
+
+   // Concatonate timestamp informatioan based on board type
+   switch( static_cast<EDigitizer>((ptr[0] >> 22) && 0x3F) ) {
+      case EDigitizer::kV1724: 
+         tmpTimestamp = tmpTimestamp<<30;
+         tmpTimestamp |= ptr[1] & 0x3ffffffF; // 30 bit timestamp
+      case EDigitizer::kV1725:
+         tmpTimestamp = tmpTimestamp<<31;
+         tmpTimestamp |= ptr[1] & 0x7ffffffF; // 31 bit timestamp
+      default:
+         tmpTimestamp = tmpTimestamp<<32;
+         tmpTimestamp |= ptr[1] & 0xffffffff; // 32 bit timestamp
    }
+   eventFrag->SetTimeStamp(tmpTimestamp);
 
-   // *=* LST File Parsing *=* //
-   // This section is for reading in V1 .lst files of a C1725 board
-   // TODO: Change this to read in both V1 and V2 type files, as well as all possible DAQ boards at ILL.
-   // This reqires reading the header at the beginning of the .lst file to find the version.
-
-   // we read 4 words for each event, and size is in bytes, so we need to divide it by 4 (size of uint32_t)
-   for(size_t i = 0; i + 3 < size / 4; i += 4) {
-      if(fItemsPopped != nullptr && fInputSize != nullptr) {
-         ++(*fItemsPopped);
-         --(*fInputSize);
-      }
-
-      // Crate: (buffer >> 28) & 0xF (4 Bits)
-      // Board: (buffer >>  22) & 0x3F (6 Bits)
-      EDigitizer Board = static_cast<EDigitizer>(( ptr[i] >> 22) & 0x3F);
-      
-      // Channel: (Buffer >> 16) & 0x3F (6 Bits)
-      eventFrag->SetAddress( (ptr[i] >> 16) & 0xffff );
-
-      //*=* Timestamp bits *=*//
-
-      // Rollover, constant beween boards
-      tmpTimestamp = ptr[i] & 0xffff;
-      tmpTimestamp = tmpTimestamp<<31;
-
-      // Concatonate timestamp informatioan
-      if( Board == EDigitizer::kV1724 ) {
-          // Timestamp bits is 30
-          tmpTimestamp |= ptr[ i + 1 ] & 0x3FFFFFFF;
-      } else if ( Board == EDigitizer::kV1725_PHA ) {
-          // Timestamp bits is 31
-          tmpTimestamp |= ptr[i + 1] & 0x7fffffff;
-      } else {
-          tmpTimestamp |= ptr[i + 1] & 0xffffffff;
-      }
-      eventFrag->SetTimeStamp(tmpTimestamp);
-
-      ++totalEventsRead;
-
-      //*=* Charge Information *=*//
-      int32_t Charge = (ptr[i+2] & 0x7FFF);
-
-      // Discriminate bad fragments
-      if( Charge == 0 || Charge == 0x8000 ) {
-         if(fRecordDiag) {
-            TParsingDiagnostics::Get()->BadFragment(99);
-         }
-         // Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, ptr, size / 4, i + 2, false));
-         continue;
-      }
-      eventFrag->SetCharge(static_cast<int32_t>(Charge) );
+   int32_t Charge = (ptr[2] & 0x7fff);
+   // Discriminate bad fragments
+   if( Charge == 0 || Charge == 0x8000 ) {
       if(fRecordDiag) {
-         TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+         TParsingDiagnostics::Get()->BadFragment(99);
       }
-      Push(fGoodOutputQueues, std::make_shared<TFragment>(*eventFrag));
-      // std::cout<<totalEventsRead<<": "<<eventFrag->Charge()<<", "<<eventFrag->GetTimeStamp()<<std::endl;
+      Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, ptr, 4, 2, false));
+      return 0;
    }
-
-   return totalEventsRead;
+   // Good event
+   eventFrag->SetCharge(static_cast<int32_t>(Charge) );
+   if(fRecordDiag) {
+      TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+   }
+   Push(fGoodOutputQueues, std::make_shared<TFragment>(*eventFrag));
+   return 1;
 }
 
+int TILLDataParser::V2SingleFippsEventToFragment(char* data)
+{
+   uint32_t* ptr = reinterpret_cast<uint32_t*>(data);
+   std::shared_ptr<TFragment> eventFrag       = std::make_shared<TFragment>();
+   Long64_t                   tmpTimestamp;
+
+   eventFrag->SetAddress( (ptr[0] >> 16) & 0xffff );
+
+   // Rollover, constant beween boards
+   tmpTimestamp = ptr[0] & 0xffff;
+   tmpTimestamp = tmpTimestamp<<32;
+   tmpTimestamp |= ptr[1] & 0xffffffff; // 32 bit timestamp
+   eventFrag->SetTimeStamp(tmpTimestamp);
+
+   int32_t Charge = (ptr[2] & 0x7fff);
+   // Discriminate bad fragments
+   if( Charge == 0 || Charge == 0x8000 ) {
+      if(fRecordDiag) {
+         TParsingDiagnostics::Get()->BadFragment(99);
+      }
+      Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, ptr, 4, 2, false));
+      return 0;
+   }
+   // Good event
+   eventFrag->SetCharge(static_cast<int32_t>(Charge) );
+   if(fRecordDiag) {
+      TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+   }
+   Push(fGoodOutputQueues, std::make_shared<TFragment>(*eventFrag));
+   return 1;
+}

--- a/libraries/TILLDataParser/TILLDataParser.cxx
+++ b/libraries/TILLDataParser/TILLDataParser.cxx
@@ -42,8 +42,8 @@ int TILLDataParser::FippsToFragment(char* data, uint32_t size)
    std::shared_ptr<TFragment> eventFrag       = std::make_shared<TFragment>();
    Long64_t                   tmpTimestamp;
    if(fItemsPopped != nullptr && fInputSize != nullptr) {
-      *fItemsPopped = 0;
-      *fInputSize   = size/16; //4 words of 4 bytes for each event
+      *fItemsPopped += 0;
+      *fInputSize   += size/16; //4 words of 4 bytes for each event
    }
 
    // *=* LST File Parsing *=* //

--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -152,6 +152,8 @@ int TLstFile::Read(std::shared_ptr<TRawEvent> Event)
    std::shared_ptr<TLstEvent> LstEvent = std::static_pointer_cast<TLstEvent>(Event);
    LstEvent->Clear();
 
+   LstEvent->SetLstVersion(fVersion);
+
 
    if(fBytesRead < fFileSize) {
       // Fill the buffer

--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -23,7 +23,7 @@
 #include "TILLMnemonic.h"
 #include "ILLDataVersion.h"
 
-#define READ_EVENT_SIZE 1000000
+#define READ_EVENT_SIZE 10000
 
 /// \cond CLASSIMP
 ClassImp(TLstFile)
@@ -122,6 +122,7 @@ bool TLstFile::Open(const char* filename)
 	TChannel::SetMnemonicClass(TILLMnemonic::Class());
 
    TRunInfo::SetRunInfo(GetRunNumber(), GetSubRunNumber());
+   TRunInfo::SetRunLength(300); 
    TRunInfo::ClearVersion();
    TRunInfo::SetVersion(ILLDATA_RELEASE);
 
@@ -157,8 +158,8 @@ int TLstFile::Read(std::shared_ptr<TRawEvent> Event)
 
    if(fBytesRead < fFileSize) {
       // Fill the buffer
+      char tempBuff[READ_EVENT_SIZE*4*sizeof(int32_t)] ; 
       try {
-         char* tempBuff = new char [READ_EVENT_SIZE*4*sizeof(int32_t)] ; 
          fInputStream.read( tempBuff, READ_EVENT_SIZE*4*sizeof(int32_t));
          LastReadSize = static_cast<size_t>(fInputStream.gcount());
          fBytesRead += LastReadSize;
@@ -168,7 +169,6 @@ int TLstFile::Read(std::shared_ptr<TRawEvent> Event)
             fReadBuffer.push_back(tempBuff[i]);
          }
 
-         delete tempBuff;
       } catch(std::exception& e) {
          std::cout<<"Caught "<<e.what() << " at " << __FILE__ << " : "  << __LINE__ <<std::endl;
       }
@@ -219,24 +219,7 @@ int TLstFile::GetRunNumber()
 
 int TLstFile::GetSubRunNumber()
 {
-   // Parse the sub run number from the current TMidasFile. This assumes a format of
-   // run#####_###.lst or run#####.lst.
-   if(fFilename.length() == 0) {
-      return -1;
-   }
-   std::size_t foundslash = fFilename.rfind('/');
-   std::size_t found      = fFilename.rfind('-');
-   if((found < foundslash && foundslash != std::string::npos) || found == std::string::npos) {
-      found = fFilename.rfind('_');
-   }
-   if(found < foundslash && foundslash != std::string::npos) {
-      found = std::string::npos;
-   }
-   if(found != std::string::npos) {
-      std::string temp = fFilename.substr(found + 1, 3);
-      // printf("%i \n",atoi(temp.c_str()));
-      return atoi(temp.c_str());
-   }
+   // There are no subruns in .lst files
    return -1;
 }
 


### PR DESCRIPTION
Fixes from #12. 

Also contains updates to the destructors and TFipps and TFippsLaBr to make them compatible with the recent changes GRSISort. ie, deep copy.

Been doing some testing lately with this code. Using GRSISort v4.0.0.2 and ROOT v6.18/04. Seems to be working fine, and everything is sorted correctly in the same was as before. However, I may not be sharing the sorting status information with GRSISort correctly (between input loop to unpack loop to frag write loop), but that doesn't affect the result of the sort. Something to look into for the future.