### PR TITLE
Fixing issue GRIFFINCollaboration/GRSISort#1166

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .build
 lib
+bin
 *.o
 *.so
 *.exe

--- a/libraries/TILLDataParser/TILLDataParser.cxx
+++ b/libraries/TILLDataParser/TILLDataParser.cxx
@@ -74,12 +74,15 @@ int TILLDataParser::V1SingleFippsEventToFragment(uint32_t* data)
       case EDigitizer::kV1724: 
          tmpTimestamp = tmpTimestamp<<30;
          tmpTimestamp |= data[1] & 0x3ffffffF; // 30 bit timestamp
+			break;
       case EDigitizer::kV1725_PHA:
          tmpTimestamp = tmpTimestamp<<31;
          tmpTimestamp |= data[1] & 0x7ffffffF; // 31 bit timestamp
+			break;
       default:
          tmpTimestamp = tmpTimestamp<<32;
          tmpTimestamp |= data[1] & 0xffffffff; // 32 bit timestamp
+			break;
    }
    eventFrag->SetTimeStamp(tmpTimestamp);
 

--- a/util/config
+++ b/util/config
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash 
+
+readlink=readlink
+if [ `uname` = "AIX" ]; then
+  readlink=echo
+fi
+
+# work around readlink versions not having -f option
+fullpath1=`$readlink $0`
+if [ "$?" -ne "0" ]; then
+  fullpath1=$0
+else
+  if [ ${fullpath1##/} = $fullpath1 ] && [ ${fullpath1##~} = $fullpath1 ]; then
+    # relative path, prepend directory where executable was found
+    lpath=`dirname $0`
+    fullpath1=$lpath/$fullpath1
+  fi
+fi
+
+progdir=`dirname $fullpath1`
+runningdir=`pwd`
+if [ ${progdir##/} != $progdir ] || [ ${progdir##~} != $progdir ]; then
+  # absolute path
+  fullpath=$progdir
+else
+  # relative path
+  if [ $progdir != "." ]; then
+    fullpath=$runningdir/$progdir
+  else
+    fullpath=$runningdir
+  fi
+fi
+
+# work around readlink versions not having -f option
+fullpath1=`$readlink $fullpath`
+if [ "$?" -ne "0" ]; then
+  fullpath1=$fullpath
+fi
+
+
+libdir=$GRSISYS/ILLData/lib
+incdir=$GRSISYS/ILLData/include
+
+libs="-lTFippsLaBr -lTFippsPulser -lTFipps -lTFippsTAC -lTILLAnalysis -lTILLDataParser -lTILLDetector -lTILLFormat -lTLst"
+
+cflags="-std=c++0x -I$incdir"
+
+usage="\
+Usage: grsi-config [--version] [--incdir] [--cflags] [--libs] [--help]"
+
+if test $# -eq 0; then
+  echo "${usage}" 1>&2
+  exit 1
+fi
+
+out=""
+
+incdirout=no
+cflagsout=no
+libsout=no
+
+while test $# -gt 0; do
+  case "$1" in 
+  -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
+  *)    optarg= ;;
+  esac
+
+  case $1 in
+    --version)
+      ### Output the version number.  If GVersion.h can not be found, give up.
+      if test -r ${incdir}/GVersion.h; then
+        out="$out `sed -n 's,.*GRSI_RELEASE *\"\(.*\)\".*,\1,p' < ${incdir}/GVersion.h`"
+      else
+        echo "cannot read ${incdir}/GVersion.h"
+        exit 1
+      fi
+      ;;
+    --incdir)
+      if test "x$incdirout" = "xyes" ; then
+        shift
+        continue
+      fi
+      incdirout="yes"
+      out="$out $incdir "
+      ;;
+    --cflags)
+      if test "x$cflagsout" = "xyes" ; then
+        shift
+        continue
+      fi
+      cflagsout="yes"
+      out="$out $cflags "
+      ;;
+    --libs)
+      if test "x$libsout" = "xyes" ; then
+        shift
+        continue
+      fi
+      libsout="yes"
+      out=$"$out -L${libdir} $libs "
+      ;;
+    --help)
+      ### Print a helpful message...
+      echo "Usage: `basename $0` [options]"
+      echo ""
+      echo "  --version       Print the current GRSI Version number."
+      echo "  --incdir        Print header path."
+      echo "  --cflags        Print compiler flags and header path."
+      echo "  --libs          Print libdir + libraries."
+      echo "  --help          Print what you see here."
+      exit 0
+      ;;
+    *)
+      ### Give an error
+      echo "Unknown argument \"$1\"!" 1>&2
+      echo "${usage}" 1>&2
+      exit 1
+      ;;
+   esac
+   shift 
+done
+
+echo $out
+


### PR DESCRIPTION
This should fix issue GRIFFINCollaboration/GRSISort#1166 and allow source code placed in the util directory to be compiled into executables. 

Also fixed a warning that came up when compiling the code, apparently some ```break;``` statements were missing in a switch clause.