### PR TITLE
Removed std::move for simple pointers

### DIFF
--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -415,8 +415,8 @@ void TFipps::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*
    switch(chan->GetMnemonic()->SubSystem()) {
 		case TMnemonic::EMnemonic::kG: 
 			{
-				auto geHit = new TFippsHit(*frag);
-				fHits.push_back(std::move(geHit));
+				auto hit = new TFippsHit(*frag);
+				fHits.push_back(hit);
 			}
 			break;
 		default:

--- a/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBr.cxx
+++ b/libraries/TILLAnalysis/TFippsLaBr/TFippsLaBr.cxx
@@ -141,6 +141,6 @@ TFippsLaBrHit* TFippsLaBr::GetSuppressedHit(const int& i)
 
 void TFippsLaBr::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
-	TFippsLaBrHit* laHit = new TFippsLaBrHit(*frag);                 // Building is controlled in the constructor of the hit
-	fHits.push_back(std::move(laHit)); // use std::move for efficienciy since laHit loses scope here anyway
+	TFippsLaBrHit* hit = new TFippsLaBrHit(*frag);                 // Building is controlled in the constructor of the hit
+	fHits.push_back(hit);
 }

--- a/libraries/TILLAnalysis/TFippsPulser/TFippsPulser.cxx
+++ b/libraries/TILLAnalysis/TFippsPulser/TFippsPulser.cxx
@@ -37,8 +37,8 @@ void TFippsPulser::AddFragment(const std::shared_ptr<const TFragment>& frag, TCh
       return;
    }
 
-   TILLDetectorHit* dethit = new TILLDetectorHit(*frag);
-   fHits.push_back(std::move(dethit));
+   TILLDetectorHit* hit = new TILLDetectorHit(*frag);
+   fHits.push_back(hit);
 }
 
 void TFippsPulser::Print(Option_t*) const

--- a/libraries/TILLAnalysis/TFippsTAC/TFippsTAC.cxx
+++ b/libraries/TILLAnalysis/TFippsTAC/TFippsTAC.cxx
@@ -45,5 +45,5 @@ void TFippsTAC::Print(Option_t*) const
 void TFippsTAC::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
 	TFippsTACHit* hit = new TFippsTACHit(*frag);
-	fHits.push_back(std::move(hit));
+	fHits.push_back(hit);
 }


### PR DESCRIPTION
See GRIFFINCollaboration/GRSISort#1196.