### PR TITLE
Fixed issue with timestamps

### DIFF
--- a/include/TILLDataParser.h
+++ b/include/TILLDataParser.h
@@ -48,15 +48,6 @@ public:
    // ENUM(EBank, char, kWFDN,kGRF1,kGRF2,kGRF3,kFME0,kFME1,kFME2,kFME3);
    enum class EBank { kWFDN = 0, kGRF1 = 1, kGRF2 = 2, kGRF3 = 3, kGRF4 = 4, kFME0 = 5, kFME1 = 6, kFME2 = 7, kFME3 = 8 };
 
-   enum class EDigitizer {
-       kV1751 = 1,
-       kV1724 = 2,
-       kV1730_PSD = 3,
-       kV1730_PHA = 4,
-       kV1725_PHA = 7,
-       kV1725_PSD = 8
-   };
-
    enum class EDataParserState {
       kGood,
       kBadHeader,

--- a/include/TLstFile.h
+++ b/include/TLstFile.h
@@ -49,14 +49,21 @@ public:
    int GetRunNumber() override;
    int GetSubRunNumber() override;
 
+   int32_t Version() { return fVersion; }
+   int32_t TimeBase() { return fTimeBase; }
+   int32_t NbEvents() { return fNbEvents; }
+   int32_t NbBoards() { return fNbBoards; }
+   int32_t* BoardHeaders() { return fBoardHeaders; }
 #ifndef __CINT__
    std::shared_ptr<TRawEvent> NewEvent() override { return std::make_shared<TLstEvent>(); }
 #endif
 private:
+	void ParseHeaders();
+
    int32_t fVersion;
    int32_t fTimeBase;
-   int32_t fnbEvents;
-   int32_t fnbBoards;
+   int32_t fNbEvents;
+   int32_t fNbBoards;
    int32_t* fBoardHeaders;
    std::ifstream fInputStream;
 

--- a/libraries/TILLDataParser/TILLDataParser.cxx
+++ b/libraries/TILLDataParser/TILLDataParser.cxx
@@ -38,7 +38,7 @@ int TILLDataParser::Process(std::shared_ptr<TRawEvent> rawEvent)
    if(fInputSize != nullptr) *fInputSize += event->GetDataSize()/16; // 16 bytes per event, number of bytes in 32bits
 
    if(event->GetLstVersion() == 1) {
-      for( size_t i = 0; i + 3 < size/4; i += 4 ) {
+      for(size_t i = 0; i + 3 < size/4; i += 4) {
          EventsProcessed += V1SingleFippsEventToFragment(EvntData + i);
          if(fItemsPopped != nullptr && fInputSize != nullptr) {
             ++(*fItemsPopped);
@@ -46,7 +46,7 @@ int TILLDataParser::Process(std::shared_ptr<TRawEvent> rawEvent)
          }
       }
    } else {
-      for( size_t i = 0; i + 3 < size / 4; i += 4 ) {
+      for(size_t i = 0; i + 3 < size / 4; i += 4) {
          EventsProcessed += V2SingleFippsEventToFragment(EvntData + i);
          if(fItemsPopped != nullptr && fInputSize != nullptr) {
             ++(*fItemsPopped);
@@ -63,20 +63,21 @@ int TILLDataParser::V1SingleFippsEventToFragment(uint32_t* data)
    std::shared_ptr<TFragment> eventFrag       = std::make_shared<TFragment>();
    Long64_t                   tmpTimestamp;
 
-   eventFrag->SetAddress( (data[0] >> 16) & 0xffff );
+	// address is 4 bit crate, 6 bit board, and 6 bit channel
+   eventFrag->SetAddress((data[0] >> 16) & 0xffff);
 
    // Rollover, constant beween boards
    tmpTimestamp = data[0] & 0xffff;
 
    // Concatenate timestamp informatioan based on board type
-   switch(static_cast<EDigitizer>((data[0] >> 22) & 0x3F) ) {
+   switch(static_cast<EDigitizer>((data[0] >> 22) & 0x3f)) {
       case EDigitizer::kV1724: 
          tmpTimestamp = tmpTimestamp<<30;
-         tmpTimestamp |= data[1] & 0x3ffffffF; // 30 bit timestamp
+         tmpTimestamp |= data[1] & 0x3fffffff; // 30 bit timestamp
 			break;
-      case EDigitizer::kV1725_PHA:
+		case EDigitizer::kV1725_PHA: // also for 1730_PSD according to Event.h from ILL
          tmpTimestamp = tmpTimestamp<<31;
-         tmpTimestamp |= data[1] & 0x7ffffffF; // 31 bit timestamp
+         tmpTimestamp |= data[1] & 0x7fffffff; // 31 bit timestamp
 			break;
       default:
          tmpTimestamp = tmpTimestamp<<32;
@@ -87,7 +88,7 @@ int TILLDataParser::V1SingleFippsEventToFragment(uint32_t* data)
 
    int32_t Charge = (data[2] & 0x7fff);
    // Discriminate bad fragments
-   if( Charge == 0 || Charge == 0x8000 ) {
+   if(Charge == 0 || Charge == 0x8000) {
       if(fRecordDiag) {
          TParsingDiagnostics::Get()->BadFragment(99);
       }
@@ -95,7 +96,7 @@ int TILLDataParser::V1SingleFippsEventToFragment(uint32_t* data)
       return 1;
    }
    // Good event
-   eventFrag->SetCharge(static_cast<int32_t>(Charge) );
+   eventFrag->SetCharge(static_cast<int32_t>(Charge));
    if(fRecordDiag) {
       TParsingDiagnostics::Get()->GoodFragment(eventFrag);
    }
@@ -108,7 +109,7 @@ int TILLDataParser::V2SingleFippsEventToFragment(uint32_t* data)
    std::shared_ptr<TFragment> eventFrag       = std::make_shared<TFragment>();
    Long64_t                   tmpTimestamp;
 
-   eventFrag->SetAddress( (data[0] >> 16) & 0xffff );
+   eventFrag->SetAddress((data[0] >> 16) & 0xffff);
 
    // Rollover, constant beween boards
    tmpTimestamp = data[0] & 0xffff;
@@ -118,7 +119,7 @@ int TILLDataParser::V2SingleFippsEventToFragment(uint32_t* data)
 
    int32_t Charge = (data[2] & 0x7fff);
    // Discriminate bad fragments
-   if( Charge == 0 || Charge == 0x8000 ) {
+   if(Charge == 0 || Charge == 0x8000) {
       if(fRecordDiag) {
          TParsingDiagnostics::Get()->BadFragment(99);
       }
@@ -126,7 +127,7 @@ int TILLDataParser::V2SingleFippsEventToFragment(uint32_t* data)
       return 1;
    }
    // Good event
-   eventFrag->SetCharge(static_cast<int32_t>(Charge) );
+   eventFrag->SetCharge(static_cast<int32_t>(Charge));
    if(fRecordDiag) {
       TParsingDiagnostics::Get()->GoodFragment(eventFrag);
    }

--- a/libraries/TLst/TLstFile.cxx
+++ b/libraries/TLst/TLstFile.cxx
@@ -101,25 +101,27 @@ bool TLstFile::Open(const char* filename)
       
       fInputStream.read(reinterpret_cast<char *>(&fVersion), sizeof(int32_t));
       fInputStream.read(reinterpret_cast<char *>(&fTimeBase), sizeof(int32_t));
-      fInputStream.read(reinterpret_cast<char *>(&fnbEvents), sizeof(int32_t));
-      fInputStream.read(reinterpret_cast<char *>(&fnbBoards), sizeof(int32_t));
+      fInputStream.read(reinterpret_cast<char *>(&fNbEvents), sizeof(int32_t));
+      fInputStream.read(reinterpret_cast<char *>(&fNbBoards), sizeof(int32_t));
       headerSize += 4*4; // 4 chucks of 4 Bytes
 
       // Read Board Headers
-      fBoardHeaders = new int32_t[fnbBoards];
-      fInputStream.read(reinterpret_cast<char *>(fBoardHeaders), fnbBoards * sizeof(uint32_t));
-      headerSize += 4*fnbBoards;
+      fBoardHeaders = new int32_t[fNbBoards];
+      fInputStream.read(reinterpret_cast<char *>(fBoardHeaders), fNbBoards * sizeof(uint32_t));
+      headerSize += 4*fNbBoards;
 
       fReadBuffer.reserve(READ_EVENT_SIZE*4*sizeof(int32_t));
       fReadBuffer.resize(READ_EVENT_SIZE*4*sizeof(int32_t));
       fInputStream.seekg(headerSize, std::ifstream::beg);
-
    } catch(std::exception& e) {
       std::cout<<"Caught "<<e.what() << " at " << __FILE__ << " : "  << __LINE__ <<std::endl;
    }
 
 	// setup TChannel to use our mnemonics
 	TChannel::SetMnemonicClass(TILLMnemonic::Class());
+
+	// parse header information
+	ParseHeaders();
 
    TRunInfo::SetRunInfo(GetRunNumber(), GetSubRunNumber());
    TRunInfo::SetRunLength(300); 
@@ -134,6 +136,54 @@ bool TLstFile::Open(const char* filename)
    return true;
 }
 
+void TLstFile::ParseHeaders()
+{
+	// loop over all board headers
+	for(uint8_t board = 0; board < fNbBoards; ++board) {
+		// get the board information
+		uint8_t crate = (fBoardHeaders[board] >> 12) & 0xf;
+		//uint16_t eventType = (fBoardHeaders[board] >> 16) & 0xffff; // not used at all??? 
+		uint8_t nbChannels = (fBoardHeaders[board] >> 6) & 0x3f;
+		uint8_t boardType = fBoardHeaders[board] & 0x3f;
+		for(uint8_t channel = 0; channel < nbChannels; ++channel) {
+			// channel address is 4 bit crate, 6 bit board, 6 bit channel
+			unsigned int address = (static_cast<unsigned int>(crate)<<12) | (static_cast<unsigned int>(board)<<6) | channel;
+
+			TChannel* tmpChan = TChannel::GetChannel(address);
+			if(tmpChan == nullptr) {
+				// ignoring crate here, so if Fipps ever changes to multiple crates this needs to be updated
+				tmpChan = new TChannel(Form("TMP%02dXX%02dX", board, channel));
+				tmpChan->SetAddress(address);
+			}
+			switch(boardType) {
+				// only V1724, V1725, V1730, and V1751 are implemented
+				// the case IDs are taken from CrateBoard.h from the ILL (assuming no difference between PHA, PSD, and waveform types)
+				case 2:
+				case 32:
+					tmpChan->SetDigitizerType(TPriorityValue<std::string>("V1724", EPriority::kInputFile));
+					break;
+				case 7:
+				case 34:
+					tmpChan->SetDigitizerType(TPriorityValue<std::string>("V1725", EPriority::kInputFile));
+					break;
+				case 3:
+				case 4:
+				case 33:
+					tmpChan->SetDigitizerType(TPriorityValue<std::string>("V1730", EPriority::kInputFile));
+					break;
+				case 1:
+				case 31:
+					tmpChan->SetDigitizerType(TPriorityValue<std::string>("V1730", EPriority::kInputFile));
+					break;
+				default:
+					std::cout<<"Warning, unknown board type "<<boardType<<" encountered, don't know what digitizer type address 0x"<<hex(address, 4)<<" is."<<std::endl;
+					break;
+			}
+			TChannel::AddChannel(tmpChan);
+		}
+	}
+}
+
 void TLstFile::Close()
 {
    fInputStream.close();
@@ -141,8 +191,6 @@ void TLstFile::Close()
 
 /// \param [in] Event Pointer to an empty TLstEvent
 /// \returns "true" for success, "false" for failure, see GetLastError() to see why
-///
-///  EDITED FROM THE ORIGINAL TO RETURN TOTAL SUCESSFULLY BYTES READ INSTEAD OF TRUE/FALSE,  PCB
 ///
 int TLstFile::Read(std::shared_ptr<TRawEvent> Event)
 {
@@ -154,7 +202,6 @@ int TLstFile::Read(std::shared_ptr<TRawEvent> Event)
    LstEvent->Clear();
 
    LstEvent->SetLstVersion(fVersion);
-
 
    if(fBytesRead < fFileSize) {
       // Fill the buffer


### PR DESCRIPTION
We noticed gaps in the timestamps because the rollover wasn't properly aligned. The old switch to decide whether it's 30, 31, or 32bit timestamps was done on the board number (how did that ever work?). Now the switch is done on the digitizer type of the channel for that address instead.

Together with setting the digitizer type for all channels from the board headers this should allow sorting data correctly without any cal-file.

The board headers are used to create a temporary cal-file with mnemonics of form "TMPboXXchX", where ```bo``` is the board number, and ```ch``` is the channel number. So far all ILL experiments use only one crate so this shouldn't be any issue.
