### PR TITLE
Fixed memory leak and GRIFFINCollaboration/GRSISort#1341 for TIfin

### DIFF
--- a/include/TIfin.h
+++ b/include/TIfin.h
@@ -105,10 +105,10 @@ private:
    mutable TTransientBits<UChar_t> fIfinBits; // Transient member flags
 
    mutable std::vector<TDetectorHit*> fAddbackHits;  //!<! Used to create addback hits on the fly
-   mutable std::vector<UShort_t>  fAddbackFrags; //!<! Number of crystals involved in creating in the addback hit
-   mutable std::vector<TDetectorHit*> fSuppressedHits;
-   mutable std::vector<TDetectorHit*> fSuppressedAddbackHits;
-   mutable std::vector<UShort_t> fSuppressedAddbackFrags;
+   mutable std::vector<UShort_t>  fAddbackFrags; //!<! Number of crystals involved in creating the addback hit
+   mutable std::vector<TDetectorHit*> fSuppressedHits; //!<! Used to create suppressed hits on the fly
+   mutable std::vector<TDetectorHit*> fSuppressedAddbackHits; //!<! Used to create suppressed addback hits on the fly
+   mutable std::vector<UShort_t> fSuppressedAddbackFrags; //!<! Number of crystals involved in creating the suppressed addback hit
 
 public:
    // static bool SetBGOHits()       { return fSetBGOHits;   }  //!<!

--- a/libraries/TILLAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TILLAnalysis/TFipps/TFipps.cxx
@@ -120,6 +120,10 @@ void TFipps::Copy(TObject& rhs) const
    // Copy function.
    TSuppressed::Copy(rhs);
 
+   for(auto& hit : static_cast<TFipps&>(rhs).fAddbackHits) delete hit;
+   for(auto& hit : static_cast<TFipps&>(rhs).fSuppressedHits) delete hit;
+   for(auto& hit : static_cast<TFipps&>(rhs).fSuppressedAddbackHits) delete hit;
+
    static_cast<TFipps&>(rhs).fAddbackHits.clear();
    static_cast<TFipps&>(rhs).fAddbackFrags.clear();
    static_cast<TFipps&>(rhs).fSuppressedHits.clear();
@@ -133,10 +137,9 @@ TFipps::~TFipps()
    // Default Destructor
 
    // fHits automatically deleted in TDetector
-   for(auto hit : fAddbackHits) delete hit;
-   for(auto hit : fSuppressedHits) delete hit;
-   for(auto hit : fSuppressedAddbackHits) delete hit;
-
+   for(auto& hit : fAddbackHits) delete hit;
+   for(auto& hit : fSuppressedHits) delete hit;
+   for(auto& hit : fSuppressedAddbackHits) delete hit;
 }
 
 void TFipps::Clear(Option_t* opt)
@@ -145,9 +148,9 @@ void TFipps::Clear(Option_t* opt)
    ClearStatus();
    TSuppressed::Clear(opt);
 
-   for(auto hit : fAddbackHits) delete hit;
-   for(auto hit : fSuppressedHits) delete hit;
-   for(auto hit : fSuppressedAddbackHits) delete hit;
+   for(auto& hit : fAddbackHits) delete hit;
+   for(auto& hit : fSuppressedHits) delete hit;
+   for(auto& hit : fSuppressedAddbackHits) delete hit;
 
    fAddbackHits.clear();
    fSuppressedHits.clear();
@@ -295,7 +298,7 @@ Int_t TFipps::GetSuppressedMultiplicity(const TBgo* bgo)
 	}
    // if the suppressed has been reset, clear the suppressed hits
    if(!IsSuppressed()) {
-		for(auto hit : sup_vec) {
+		for(auto& hit : sup_vec) {
          delete hit;
       }
       sup_vec.clear();
@@ -325,7 +328,7 @@ Int_t TFipps::GetAddbackMultiplicity()
 
    // if the addback has been reset, clear the addback hits
    if(!IsAddbackSet()) {
-		for(auto hit : ab_vec) {
+		for(auto& hit : ab_vec) {
          delete hit;
       }
       ab_vec.clear();
@@ -356,7 +359,7 @@ Int_t TFipps::GetSuppressedAddbackMultiplicity(const TBgo* bgo)
 
    // if the addback has been reset, clear the addback hits
    if(!IsSuppressedAddbackSet()) {
-		for(auto hit : ab_vec) {
+		for(auto& hit : ab_vec) {
          delete hit;
       }
       ab_vec.clear();
@@ -471,7 +474,7 @@ void TFipps::ResetAddback()
 {
    SetAddback(false);
    SetCrossTalk(false);
-	for(auto hit : GetAddbackVector()) {
+	for(auto& hit : GetAddbackVector()) {
       delete hit;
    }
    GetAddbackVector().clear();
@@ -481,7 +484,7 @@ void TFipps::ResetAddback()
 void TFipps::ResetSuppressed()
 {
     SetSuppressed(false);
-	 for(auto hit : GetSuppressedVector()) {
+	 for(auto& hit : GetSuppressedVector()) {
       delete hit;
    }
     GetSuppressedVector().clear();
@@ -493,7 +496,7 @@ void TFipps::ResetSuppressedAddback()
    SetCrossTalk(false);
    SetSuppressed(false);
    SetSuppressedAddback(false);
-	for(auto hit : GetSuppressedAddbackVector()) {
+	for(auto& hit : GetSuppressedAddbackVector()) {
       delete hit;
    }
    GetSuppressedAddbackVector().clear();

--- a/libraries/TILLAnalysis/TIfin/TIfin.cxx
+++ b/libraries/TILLAnalysis/TIfin/TIfin.cxx
@@ -132,6 +132,10 @@ void TIfin::Copy(TObject& rhs) const
    // Copy function.
    TSuppressed::Copy(rhs);
 
+   for(auto& hit : static_cast<TIfin&>(rhs).fAddbackHits) delete hit;
+   for(auto& hit : static_cast<TIfin&>(rhs).fSuppressedHits) delete hit;
+   for(auto& hit : static_cast<TIfin&>(rhs).fSuppressedAddbackHits) delete hit;
+
    static_cast<TIfin&>(rhs).fAddbackHits.clear();
    static_cast<TIfin&>(rhs).fAddbackFrags.clear();
    static_cast<TIfin&>(rhs).fSuppressedHits.clear();
@@ -145,9 +149,9 @@ TIfin::~TIfin()
    // Default Destructor
 
    // fHits automatically deleted in TDetector
-   for( auto hit : fAddbackHits ) delete hit;
-   for( auto hit : fSuppressedHits ) delete hit;
-   for( auto hit : fSuppressedAddbackHits ) delete hit;
+   for(auto& hit : fAddbackHits) delete hit;
+   for(auto& hit : fSuppressedHits) delete hit;
+   for(auto& hit : fSuppressedAddbackHits) delete hit;
 
 }
 
@@ -157,10 +161,9 @@ void TIfin::Clear(Option_t* opt)
    ClearStatus();
    TSuppressed::Clear(opt);
 
-
-   for( auto hit : fAddbackHits ) delete hit;
-   for( auto hit : fSuppressedHits ) delete hit;
-   for( auto hit : fSuppressedAddbackHits ) delete hit;
+   for(auto& hit : fAddbackHits) delete hit;
+   for(auto& hit : fSuppressedHits) delete hit;
+   for(auto& hit : fSuppressedAddbackHits) delete hit;
 
    fAddbackHits.clear();
    fSuppressedHits.clear();
@@ -308,6 +311,9 @@ Int_t TIfin::GetSuppressedMultiplicity(const TBgo* bgo)
 	}
    // if the suppressed has been reset, clear the suppressed hits
    if(!IsSuppressed()) {
+		for(auto& hit : sup_vec) {
+			delete hit;
+		}
       sup_vec.clear();
    }
    if(sup_vec.empty()) {
@@ -336,6 +342,9 @@ Int_t TIfin::GetAddbackMultiplicity()
 
    // if the addback has been reset, clear the addback hits
    if(!IsAddbackSet()) {
+		for(auto& hit : ab_vec) {
+			delete hit;
+		}
       ab_vec.clear();
       frag_vec.clear();
    }
@@ -355,7 +364,7 @@ Int_t TIfin::GetSuppressedAddbackMultiplicity(const TBgo* bgo)
    if(!IsCrossTalkSet()) {
       FixCrossTalk();
    }
-   auto& hit_vec  = GetSuppressedVector();
+   auto& hit_vec  = GetHitVector();
    auto& ab_vec   = GetSuppressedAddbackVector();
    auto& frag_vec = GetSuppressedAddbackFragVector();
    if(hit_vec.empty()) {
@@ -364,6 +373,9 @@ Int_t TIfin::GetSuppressedAddbackMultiplicity(const TBgo* bgo)
 
    // if the addback has been reset, clear the addback hits
    if(!IsAddbackSet()) {
+		for(auto& hit : ab_vec) {
+			delete hit;
+		}
       ab_vec.clear();
       frag_vec.clear();
    }
@@ -476,14 +488,20 @@ void TIfin::ResetAddback()
 {
    SetAddback(false);
    SetCrossTalk(false);
+	for(auto& hit : GetAddbackVector()) {
+		delete hit;
+	}
    GetAddbackVector().clear();
    GetAddbackFragVector().clear();
 }
 
 void TIfin::ResetSuppressed()
 {
-    SetSuppressed(false);
-    GetSuppressedVector().clear();
+	SetSuppressed(false);
+	for(auto& hit : GetSuppressedVector()) {
+		delete hit;
+	}
+	GetSuppressedVector().clear();
 }
 
 void TIfin::ResetSuppressedAddback()
@@ -491,6 +509,9 @@ void TIfin::ResetSuppressedAddback()
    SetAddback(false);
    SetCrossTalk(false);
    SetSuppressed(false);
+	for(auto& hit : GetSuppressedAddbackVector()) {
+		delete hit;
+	}
    GetSuppressedAddbackVector().clear();
    GetSuppressedAddbackFragVector().clear();
 }


### PR DESCRIPTION
Also changed some ```for(auto ``` to ```for(auto& ``` to avoid unnecessary copies. These are all pointers so the copying isn't expensive, but it probably better to get into the habit.